### PR TITLE
fix: Integrated Interface part patterns lost on world reload

### DIFF
--- a/src/main/java/io/github/lounode/ae2cs/common/me/logic/IntegratedInterfaceLogic.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/me/logic/IntegratedInterfaceLogic.java
@@ -1034,6 +1034,10 @@ public class IntegratedInterfaceLogic implements IConfigurableObject, IUpgradeab
         // 升级
         this.upgrades.readFromNBT(tag, "upgrades");
 
+        // 样板槽 — 必须在配置之前加载，否则配置加载触发 onChangeInventory
+        // → updatePatterns() 时样板槽还是空的，会导致已解码样板列表被清空
+        this.patternInventory.readFromNBT(tag, "patterns");
+
         // 配置
         this.configInv.readFromChildTag(tag, "config");
 
@@ -1045,9 +1049,6 @@ public class IntegratedInterfaceLogic implements IConfigurableObject, IUpgradeab
 
         // 机器配置
         this.configManager.readFromNBT(tag);
-
-        // 样板槽
-        this.patternInventory.readFromNBT(tag, "patterns");
 
         // 配置读完后要重新计算 hasConfig + plannedWork
         readConfig();

--- a/src/main/java/io/github/lounode/ae2cs/common/me/part/IntegratedInterfacePart.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/me/part/IntegratedInterfacePart.java
@@ -200,6 +200,7 @@ public class IntegratedInterfacePart extends AEBasePart implements IntegratedInt
     public void writeToNBT(CompoundTag data)
     {
         super.writeToNBT(data);
+        this.logic.save(data);
         data.putInt("priority", this.priority);
     }
 
@@ -207,6 +208,7 @@ public class IntegratedInterfacePart extends AEBasePart implements IntegratedInt
     public void readFromNBT(CompoundTag data)
     {
         super.readFromNBT(data);
+        this.logic.load(data);
         this.priority = data.getInt("priority");
     }
 


### PR DESCRIPTION
## Bug 描述

ME集成接口（Integrated Interface，部件形式）中已写入的编码样板在退出存档重进后消失。
普通版（9槽）和扩展版（36槽）均受影响。方块形式不受影响。

## 复现步骤

1. 在 ME 线缆上放置集成接口部件（普通或扩展版）
2. 在 GUI 中放入编码样板（合成样板/处理样板）
3. 保存并退出存档
4. 重新进入存档
5. 打开 GUI，样板已消失

## 根因

`IntegratedInterfacePart.writeToNBT()` 和 `readFromNBT()` 只持久化了 `priority` 字段：

```java
// 修复前
public void writeToNBT(CompoundTag data) {
    super.writeToNBT(data);
    data.putInt("priority", this.priority);  // 只保存了 priority
}
完全遗漏了 logic.save() / logic.load() 调用。而 所有逻辑数据（config、storage、upgrades、样板槽、crafting tracker 等）都由 IntegratedInterfaceLogic.save() / load() 负责序列化。

对比 AE2 原版的 PatternProviderPart，其在同样的方法中正确调用了 this.logic.writeToNBT(data) 和 this.logic.readFromNBT(data)。

修复
1. IntegratedInterfacePart（核心修复）

public void writeToNBT(CompoundTag data) {
    super.writeToNBT(data);
    this.logic.save(data);                  // 新增：保存全部逻辑数据
    data.putInt("priority", this.priority);
}

public void readFromNBT(CompoundTag data) {
    super.readFromNBT(data);
    this.logic.load(data);                  // 新增：加载全部逻辑数据
    this.priority = data.getInt("priority");
}
2. IntegratedInterfaceLogic.load()（加固修复）
将 patternInventory.readFromNBT() 调用移到 configInv.readFromChildTag() 之前。
原因是配置加载会触发 onChangeInventory → updatePatterns()，若此时样板槽尚未加载，
已解码的样板列表会被清空。提前加载样板槽可避免这一问题。

测试
 1.20.1 Forge：普通版和扩展版集成接口部件，样板退出重进后保留
 1.21.1 NeoForge：同上
影响范围
仅修改 IntegratedInterfacePart 和 IntegratedInterfaceLogic 两个文件，
不影响其他功能模块。
