### PR TITLE
fix: re-register patterns with ME network after world reload

### DIFF
--- a/src/main/java/io/github/lounode/ae2cs/common/me/logic/IntegratedInterfaceLogic.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/me/logic/IntegratedInterfaceLogic.java
@@ -177,7 +177,7 @@ public class IntegratedInterfaceLogic implements IConfigurableObject, IUpgradeab
      * 是否配置了备货内容（有 config 的话对外暴露本地库存，没有的话暴露网络）
      */
     private boolean hasConfig = false;
-
+    private boolean needsPatternReRegister = false;
     /**
      * 本地库存的 MEStorage 视图，用于给存储总线看
      */
@@ -364,14 +364,18 @@ public class IntegratedInterfaceLogic implements IConfigurableObject, IUpgradeab
         patternInputs.clear();
 
         BlockEntity blockEntity = host.getBlockEntity();
+        Level level = blockEntity != null ? blockEntity.getLevel() : null;
+        int slotCount = this.patternInventory.size();
+        int decodedCount = 0;
 
         for (ItemStack stack : this.patternInventory)
         {
-            IPatternDetails details = PatternDetailsHelper.decodePattern(stack, blockEntity.getLevel());
+            IPatternDetails details = PatternDetailsHelper.decodePattern(stack, level);
 
             if (details != null)
             {
                 patterns.add(details);
+                decodedCount++;
 
                 for (IPatternDetails.IInput iinput : details.getInputs())
                 {
@@ -961,6 +965,12 @@ public class IntegratedInterfaceLogic implements IConfigurableObject, IUpgradeab
                 return TickRateModulation.SLEEP;
             }
 
+            if (needsPatternReRegister)
+            {
+                updatePatterns();
+                needsPatternReRegister = false;
+            }
+
             boolean didSomething = updateStorage() | sendStacksOut();
 
             boolean stillHasWork = hasStorageWork() || !sendList.isEmpty();
@@ -1055,6 +1065,7 @@ public class IntegratedInterfaceLogic implements IConfigurableObject, IUpgradeab
 
         // 样板槽更新 patternInputs / patterns 列表
         updatePatterns();
+        needsPatternReRegister = true;
 
         // 样板推送状态
         this.roundRobinIndex = tag.getInt("roundRobinIndex");

--- a/src/main/java/io/github/lounode/ae2cs/common/me/logic/IntegratedInterfaceLogic.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/me/logic/IntegratedInterfaceLogic.java
@@ -365,8 +365,12 @@ public class IntegratedInterfaceLogic implements IConfigurableObject, IUpgradeab
 
         BlockEntity blockEntity = host.getBlockEntity();
         Level level = blockEntity != null ? blockEntity.getLevel() : null;
-        int slotCount = this.patternInventory.size();
-        int decodedCount = 0;
+        if (level == null)
+        {
+            needsPatternReRegister = true;
+            ICraftingProvider.requestUpdate(mainNode);
+            return;
+        }
 
         for (ItemStack stack : this.patternInventory)
         {
@@ -375,7 +379,6 @@ public class IntegratedInterfaceLogic implements IConfigurableObject, IUpgradeab
             if (details != null)
             {
                 patterns.add(details);
-                decodedCount++;
 
                 for (IPatternDetails.IInput iinput : details.getInputs())
                 {

--- a/src/main/java/io/github/lounode/ae2cs/common/me/part/IntegratedInterfacePart.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/me/part/IntegratedInterfacePart.java
@@ -1,6 +1,7 @@
 package io.github.lounode.ae2cs.common.me.part;
 
 import appeng.api.behaviors.GenericInternalInventory;
+import appeng.api.networking.IGridNodeListener;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
@@ -86,6 +87,11 @@ public class IntegratedInterfacePart extends AEBasePart implements IntegratedInt
         return super.getCapability(capabilityClass);
     }
 
+    @Override
+    protected void onMainNodeStateChanged(IGridNodeListener.State reason) {
+        super.onMainNodeStateChanged(reason);
+        this.logic.onMainNodeStateChanged();
+    }
 
     @Override
     public void getBoxes(IPartCollisionHelper bch)


### PR DESCRIPTION
After world reload, patterns persist in the slots but are not recognized by the ME network because PatternDetailsHelper .decodePattern() requires a non-null Level, which is unavailable during NBT deserialization (load() is called before the block entity is added to the world).

Fix: defer pattern decoding to the first tick after grid boot, when Level is available. The ticker calls updatePatterns() which re-decodes patterns with a valid Level and automatically calls ICraftingProvider.requestUpdate() to register them with the crafting service.

Also add onMainNodeStateChanged() override to IntegratedInterfacePart to forward the event to the logic, ensuring the ticker is awakened.