### PR TITLE
fix: register IItemHandler/IFluidHandler for IntegratedInterface

### DIFF
--- a/src/main/java/io/github/lounode/ae2cs/common/block/entity/IntegratedInterfaceBlockEntity.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/block/entity/IntegratedInterfaceBlockEntity.java
@@ -8,6 +8,8 @@ import appeng.api.stacks.AEItemKey;
 import appeng.block.crafting.PatternProviderBlock;
 import appeng.block.crafting.PushDirection;
 import appeng.blockentity.grid.AENetworkedBlockEntity;
+import appeng.helpers.externalstorage.GenericStackFluidStorage;
+import appeng.helpers.externalstorage.GenericStackItemStorage;
 import appeng.util.SettingsFrom;
 import io.github.lounode.ae2cs.common.init.AECSBlockEntities;
 import io.github.lounode.ae2cs.common.init.AECSBlocks;
@@ -23,6 +25,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import org.jetbrains.annotations.Nullable;
 
@@ -59,6 +62,22 @@ public class IntegratedInterfaceBlockEntity extends AENetworkedBlockEntity imple
                 AECSBlockEntities.INTEGRATED_INTERFACE_BLOCK_ENTITY.get(),
                 (be, direction) -> be.getLogic().getExposedMEStorage(direction)
         );
+        event.registerBlockEntity(
+                Capabilities.ItemHandler.BLOCK,
+                AECSBlockEntities.INTEGRATED_INTERFACE_BLOCK_ENTITY.get(),
+                (be, direction) -> {
+                    var inv = be.getLogic().getStorageInv();
+                    return inv != null ? new GenericStackItemStorage(inv) : null;
+                }
+        );
+        event.registerBlockEntity(
+                Capabilities.FluidHandler.BLOCK,
+                AECSBlockEntities.INTEGRATED_INTERFACE_BLOCK_ENTITY.get(),
+                (be, direction) -> {
+                    var inv = be.getLogic().getStorageInv();
+                    return inv != null ? new GenericStackFluidStorage(inv) : null;
+                }
+        );
 
         event.registerBlockEntity(
                 AECapabilities.GENERIC_INTERNAL_INV,
@@ -69,6 +88,22 @@ public class IntegratedInterfaceBlockEntity extends AENetworkedBlockEntity imple
                 AECapabilities.ME_STORAGE,
                 AECSBlockEntities.EX_INTEGRATED_INTERFACE_BLOCK_ENTITY.get(),
                 (be, direction) -> be.getLogic().getExposedMEStorage(direction)
+        );
+        event.registerBlockEntity(
+                Capabilities.ItemHandler.BLOCK,
+                AECSBlockEntities.EX_INTEGRATED_INTERFACE_BLOCK_ENTITY.get(),
+                (be, direction) -> {
+                    var inv = be.getLogic().getStorageInv();
+                    return inv != null ? new GenericStackItemStorage(inv) : null;
+                }
+        );
+        event.registerBlockEntity(
+                Capabilities.FluidHandler.BLOCK,
+                AECSBlockEntities.EX_INTEGRATED_INTERFACE_BLOCK_ENTITY.get(),
+                (be, direction) -> {
+                    var inv = be.getLogic().getStorageInv();
+                    return inv != null ? new GenericStackFluidStorage(inv) : null;
+                }
         );
     }
 

--- a/src/main/java/io/github/lounode/ae2cs/common/me/part/IntegratedInterfacePart.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/me/part/IntegratedInterfacePart.java
@@ -7,6 +7,8 @@ import appeng.api.parts.IPartModel;
 import appeng.api.parts.RegisterPartCapabilitiesEvent;
 import appeng.api.stacks.AEItemKey;
 import appeng.core.AppEng;
+import appeng.helpers.externalstorage.GenericStackFluidStorage;
+import appeng.helpers.externalstorage.GenericStackItemStorage;
 import appeng.items.parts.PartModels;
 import appeng.menu.locator.MenuLocators;
 import appeng.parts.AEBasePart;
@@ -24,6 +26,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.capabilities.Capabilities;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumSet;
@@ -78,6 +81,22 @@ public class IntegratedInterfacePart extends AEBasePart implements IntegratedInt
         event.register(
                 AECapabilities.ME_STORAGE,
                 (part, direction) -> part.getLogic().getExposedMEStorage(direction),
+                IntegratedInterfacePart.class
+        );
+        event.register(
+                Capabilities.ItemHandler.BLOCK,
+                (part, direction) -> {
+                    var inv = part.getLogic().getStorageInv();
+                    return inv != null ? new GenericStackItemStorage(inv) : null;
+                },
+                IntegratedInterfacePart.class
+        );
+        event.register(
+                Capabilities.FluidHandler.BLOCK,
+                (part, direction) -> {
+                    var inv = part.getLogic().getStorageInv();
+                    return inv != null ? new GenericStackFluidStorage(inv) : null;
+                },
                 IntegratedInterfacePart.class
         );
     }


### PR DESCRIPTION
External pipes query IItemHandler/IFluidHandler but the IntegratedInterfacePart and IntegratedInterfaceBlockEntity only exposed AE2's internal GENERIC_INTERNAL_INV capability. This prevents external pipes (Mekanism, Pipez, etc.) from connecting to the interface's storage slots.

Add direct IItemHandler/IFluidHandler capability registrations using GenericStackItemStorage/GenericStackFluidStorage wrappers in both the block entity and cable part forms.