### PR TITLE
修复CF发布

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,10 +131,11 @@ jobs:
           LOADER: ${{ inputs.branch == '1.20.1' && 'forge' || 'neoforge' }}
           JAVA: ${{ inputs.branch == '26.1' && '25' || inputs.branch == '1.21.1' && '21' || '17' }}
           VERSION_TYPE: 'release'
-        uses: Kir-Antipov/mc-publish@v3.3.0
+        uses: Kir-Antipov/mc-publish@v3.3.1
         with:
           curseforge-id: 1435174
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          environment: 'client | server'
           files: |
             ./ae2cs-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar
             ./!(ae2cs-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar)


### PR DESCRIPTION
## 变更内容
- 更新 mc-publish 至 3.3.1。
- 为 CurseForge 发布声明 client 和 server 环境，修复 CF 发布元数据。

## 验证
- 已审阅工作流差异。