### PR TITLE
调整供应器绑定器交互

### DIFF
--- a/src/main/java/io/github/lounode/ae2cs/client/eventlistener/ResonatingLinkerListener.java
+++ b/src/main/java/io/github/lounode/ae2cs/client/eventlistener/ResonatingLinkerListener.java
@@ -1,0 +1,40 @@
+package io.github.lounode.ae2cs.client.eventlistener;
+
+import io.github.lounode.ae2cs.api.ids.AECSConstants;
+import io.github.lounode.ae2cs.common.item.ResonatingLinkerItem;
+import io.github.lounode.ae2cs.network.c2s.ResonatingLinkerBatchApplyPacket;
+
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.common.util.TriState;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+@EventBusSubscriber(modid = AECSConstants.MODID, value = Dist.CLIENT)
+public class ResonatingLinkerListener {
+
+    @SubscribeEvent
+    public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
+        if (!Screen.hasControlDown() || event.getEntity().isShiftKeyDown()) {
+            return;
+        }
+
+        if (!(event.getItemStack().getItem() instanceof ResonatingLinkerItem)) {
+            return;
+        }
+
+        event.setUseBlock(TriState.FALSE);
+        event.setUseItem(TriState.FALSE);
+        event.setCancellationResult(InteractionResult.SUCCESS);
+        event.setCanceled(true);
+        PacketDistributor.sendToServer(new ResonatingLinkerBatchApplyPacket(event.getPos(),
+                event.getHand() == InteractionHand.MAIN_HAND,
+                event.getHitVec().getLocation().x,
+                event.getHitVec().getLocation().y,
+                event.getHitVec().getLocation().z));
+    }
+}

--- a/src/main/java/io/github/lounode/ae2cs/common/init/AECSPackets.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/init/AECSPackets.java
@@ -2,6 +2,7 @@ package io.github.lounode.ae2cs.common.init;
 
 import io.github.lounode.ae2cs.api.ids.AECSConstants;
 import io.github.lounode.ae2cs.network.c2s.MirrorLinkerBatchApplyPacket;
+import io.github.lounode.ae2cs.network.c2s.ResonatingLinkerBatchApplyPacket;
 import io.github.lounode.ae2cs.network.c2s.ScrollResonatingPatternSelectPacket;
 import io.github.lounode.ae2cs.network.c2s.SideConfigMenuOpenPacket;
 
@@ -39,5 +40,12 @@ public class AECSPackets {
                 new DirectionalPayloadHandler<>(
                         MirrorLinkerBatchApplyPacket::handle,
                         MirrorLinkerBatchApplyPacket::handle));
+
+        registrar.playBidirectional(
+                ResonatingLinkerBatchApplyPacket.TYPE,
+                ResonatingLinkerBatchApplyPacket.STREAM_CODEC,
+                new DirectionalPayloadHandler<>(
+                        ResonatingLinkerBatchApplyPacket::handle,
+                        ResonatingLinkerBatchApplyPacket::handle));
     }
 }

--- a/src/main/java/io/github/lounode/ae2cs/common/item/MirrorLinkerItem.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/item/MirrorLinkerItem.java
@@ -127,7 +127,9 @@ public class MirrorLinkerItem extends Item {
                 continue;
             }
 
-            List<MirrorPatternProviderHost> atCurrent = PatternProviderBindingHelper.getMirrorProvidersAt(level, current);
+            List<MirrorPatternProviderHost> atCurrent = PatternProviderBindingHelper.getMirrorProvidersAt(level, current).stream()
+                    .filter(host -> host.getClass() == selected.getClass())
+                    .toList();
             if (atCurrent.isEmpty()) {
                 continue;
             }

--- a/src/main/java/io/github/lounode/ae2cs/common/item/MirrorPatternProviderBlockItem.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/item/MirrorPatternProviderBlockItem.java
@@ -1,56 +1,11 @@
 package io.github.lounode.ae2cs.common.item;
 
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.InteractionResultHolder;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TooltipFlag;
-import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-
-import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
 
 public class MirrorPatternProviderBlockItem extends BlockItem {
 
     public MirrorPatternProviderBlockItem(Block block, Properties properties) {
         super(block, properties);
-    }
-
-    @Override
-    public @NotNull InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
-        return SimplePatternProviderMirrorHelper.tryBind(stack, context);
-    }
-
-    @Override
-    public @NotNull InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand usedHand) {
-        ItemStack stack = player.getItemInHand(usedHand);
-        InteractionResult result = SimplePatternProviderMirrorHelper.tryClear(stack, player);
-        if (result != InteractionResult.PASS) {
-            return InteractionResultHolder.sidedSuccess(stack, level.isClientSide());
-        }
-        return super.use(level, player, usedHand);
-    }
-
-    @Override
-    public void appendHoverText(@NotNull ItemStack stack, Item.TooltipContext context, @NotNull List<Component> tooltipComponents, @NotNull TooltipFlag tooltipFlag) {
-        super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
-        var target = SimplePatternProviderMirrorHelper.getTarget(stack);
-        if (target == null) {
-            tooltipComponents.add(Component.translatable("ae2cs.item.mirror_pattern_provider.target.unbound").withStyle(net.minecraft.ChatFormatting.GRAY));
-            return;
-        }
-
-        var pos = target.pos().pos();
-        tooltipComponents.add(Component.translatable("ae2cs.item.mirror_pattern_provider.target.pos", pos.getX(), pos.getY(), pos.getZ()).withStyle(net.minecraft.ChatFormatting.GRAY));
-        tooltipComponents.add(Component.translatable("ae2cs.item.mirror_pattern_provider.target.side",
-                target.side() == null ? Component.translatable("ae2cs.item.mirror_pattern_provider.target.side.block") : Component.literal(target.side().getName()))
-                .withStyle(net.minecraft.ChatFormatting.GRAY));
     }
 }

--- a/src/main/java/io/github/lounode/ae2cs/common/item/MirrorPatternProviderPartItem.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/item/MirrorPatternProviderPartItem.java
@@ -4,55 +4,9 @@ import io.github.lounode.ae2cs.common.me.part.MirrorPatternProviderPart;
 
 import appeng.items.parts.PartItem;
 
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.InteractionResultHolder;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TooltipFlag;
-import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.level.Level;
-
-import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
-
 public class MirrorPatternProviderPartItem extends PartItem<MirrorPatternProviderPart> {
 
     public MirrorPatternProviderPartItem(Properties properties) {
         super(properties, MirrorPatternProviderPart.class, MirrorPatternProviderPart::new);
-    }
-
-    @Override
-    public @NotNull InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
-        return SimplePatternProviderMirrorHelper.tryBind(stack, context);
-    }
-
-    @Override
-    public @NotNull InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand usedHand) {
-        ItemStack stack = player.getItemInHand(usedHand);
-        InteractionResult result = SimplePatternProviderMirrorHelper.tryClear(stack, player);
-        if (result != InteractionResult.PASS) {
-            return InteractionResultHolder.sidedSuccess(stack, level.isClientSide());
-        }
-        return super.use(level, player, usedHand);
-    }
-
-    @Override
-    public void appendHoverText(@NotNull ItemStack stack, Item.TooltipContext context, @NotNull List<Component> tooltipComponents, @NotNull TooltipFlag tooltipFlag) {
-        super.appendHoverText(stack, context, tooltipComponents, tooltipFlag);
-        var target = SimplePatternProviderMirrorHelper.getTarget(stack);
-        if (target == null) {
-            tooltipComponents.add(Component.translatable("ae2cs.item.mirror_pattern_provider.target.unbound").withStyle(net.minecraft.ChatFormatting.GRAY));
-            return;
-        }
-
-        var pos = target.pos().pos();
-        tooltipComponents.add(Component.translatable("ae2cs.item.mirror_pattern_provider.target.pos", pos.getX(), pos.getY(), pos.getZ()).withStyle(net.minecraft.ChatFormatting.GRAY));
-        tooltipComponents.add(Component.translatable("ae2cs.item.mirror_pattern_provider.target.side",
-                target.side() == null ? Component.translatable("ae2cs.item.mirror_pattern_provider.target.side.block") : Component.literal(target.side().getName()))
-                .withStyle(net.minecraft.ChatFormatting.GRAY));
     }
 }

--- a/src/main/java/io/github/lounode/ae2cs/common/item/PatternProviderBindingHelper.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/item/PatternProviderBindingHelper.java
@@ -43,6 +43,11 @@ public final class PatternProviderBindingHelper {
         return host instanceof ResonatingPatternProviderHost resonating ? resonating : null;
     }
 
+    public static @Nullable ResonatingPatternProviderHost resolveResonatingProvider(Level level, BlockPos pos, Vec3 clickLocation) {
+        PatternProviderLogicHost host = resolvePatternProvider(level, pos, clickLocation);
+        return host instanceof ResonatingPatternProviderHost resonating ? resonating : null;
+    }
+
     public static @Nullable MirrorPatternProviderHost resolveClickedMirrorProvider(UseOnContext context) {
         PatternProviderLogicHost host = resolveClickedPatternProvider(context);
         return host instanceof MirrorPatternProviderHost mirror ? mirror : null;
@@ -65,6 +70,25 @@ public final class PatternProviderBindingHelper {
                 var part = partHost.getPart(side);
                 if (part instanceof MirrorPatternProviderHost mirror) {
                     hosts.add(mirror);
+                }
+            }
+        }
+
+        return hosts;
+    }
+
+    public static List<ResonatingPatternProviderHost> getResonatingProvidersAt(Level level, BlockPos pos) {
+        List<ResonatingPatternProviderHost> hosts = new ArrayList<>();
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof ResonatingPatternProviderHost resonating) {
+            hosts.add(resonating);
+        }
+
+        if (be instanceof IPartHost partHost) {
+            for (Direction side : Direction.values()) {
+                var part = partHost.getPart(side);
+                if (part instanceof ResonatingPatternProviderHost resonating) {
+                    hosts.add(resonating);
                 }
             }
         }

--- a/src/main/java/io/github/lounode/ae2cs/common/item/ResonatingLinkerItem.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/item/ResonatingLinkerItem.java
@@ -4,16 +4,31 @@ import io.github.lounode.ae2cs.common.me.crafting.ResonatingProviderDefaults;
 import io.github.lounode.ae2cs.common.me.logic.ResonatingPatternProviderHost;
 
 import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+
 public class ResonatingLinkerItem extends Item implements IResonatingTargetModeItem {
+
+    private static final int MAX_BATCH_RADIUS = 16;
+    private static final int MAX_BATCH_PROVIDERS = 256;
+    private static final double MAX_BATCH_DISTANCE_SQR = 64.0D;
 
     public ResonatingLinkerItem(Properties properties) {
         super(properties.stacksTo(1));
@@ -47,5 +62,66 @@ public class ResonatingLinkerItem extends Item implements IResonatingTargetModeI
 
     public static boolean hasStoredTargets(ItemStack stack) {
         return ResonatingProviderDefaults.hasAnyTarget(ResonatingProviderDefaults.readTargets(stack));
+    }
+
+    public static int applyStoredTargetsToCluster(ItemStack stack, Player player, Level level, BlockPos centerPos, Vec3 clickLocation) {
+        if (level.isClientSide() || !level.hasChunkAt(centerPos)) {
+            return 0;
+        }
+
+        if (player.distanceToSqr(centerPos.getX() + 0.5D, centerPos.getY() + 0.5D, centerPos.getZ() + 0.5D) > MAX_BATCH_DISTANCE_SQR) {
+            return 0;
+        }
+
+        if (!player.mayUseItemAt(centerPos, Direction.UP, stack)) {
+            return 0;
+        }
+
+        ResonatingPatternProviderHost selected = PatternProviderBindingHelper.resolveResonatingProvider(level, centerPos, clickLocation);
+        if (selected == null) {
+            return 0;
+        }
+
+        Set<ResonatingPatternProviderHost> hosts = new LinkedHashSet<>();
+        Set<BlockPos> visited = new HashSet<>();
+        Queue<BlockPos> pending = new ArrayDeque<>();
+        pending.add(centerPos);
+
+        while (!pending.isEmpty() && hosts.size() < MAX_BATCH_PROVIDERS) {
+            BlockPos current = pending.poll();
+            if (!visited.add(current) || !isWithinBatchBounds(centerPos, current) || !level.hasChunkAt(current)) {
+                continue;
+            }
+
+            List<ResonatingPatternProviderHost> atCurrent = PatternProviderBindingHelper.getResonatingProvidersAt(level, current).stream()
+                    .filter(host -> host.getClass() == selected.getClass())
+                    .toList();
+            if (atCurrent.isEmpty()) {
+                continue;
+            }
+
+            hosts.addAll(atCurrent);
+            for (Direction direction : Direction.values()) {
+                BlockPos next = current.relative(direction);
+                if (!visited.contains(next) && isWithinBatchBounds(centerPos, next)) {
+                    pending.add(next);
+                }
+            }
+        }
+
+        for (ResonatingPatternProviderHost host : hosts) {
+            host.readDefaultsFromItem(stack);
+            host.markForLogicClientUpdate();
+        }
+
+        if (!player.level().isClientSide()) {
+            player.displayClientMessage(Component.translatable("ae2cs.msg.resonating_linker.applied")
+                    .withStyle(ChatFormatting.GRAY), true);
+        }
+        return hosts.size();
+    }
+
+    private static boolean isWithinBatchBounds(BlockPos center, BlockPos pos) {
+        return Math.abs(pos.getX() - center.getX()) <= MAX_BATCH_RADIUS && Math.abs(pos.getY() - center.getY()) <= MAX_BATCH_RADIUS && Math.abs(pos.getZ() - center.getZ()) <= MAX_BATCH_RADIUS;
     }
 }

--- a/src/main/java/io/github/lounode/ae2cs/common/item/ResonatingPatternProviderBlockItem.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/item/ResonatingPatternProviderBlockItem.java
@@ -1,27 +1,11 @@
 package io.github.lounode.ae2cs.common.item;
 
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.Block;
 
-import org.jetbrains.annotations.NotNull;
-
-public class ResonatingPatternProviderBlockItem extends BlockItem implements IResonatingTargetModeItem {
+public class ResonatingPatternProviderBlockItem extends BlockItem {
 
     public ResonatingPatternProviderBlockItem(Block block, Properties properties) {
         super(block, properties);
-    }
-
-    @Override
-    public @NotNull InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
-        return ResonatingProviderItemHelper.onItemUseFirst(stack, context);
-    }
-
-    @Override
-    public void scrollSelectedInputAndToast(Player player, ItemStack stack, boolean next) {
-        ResonatingProviderItemHelper.scrollSelectedInputAndToast(player, stack, next);
     }
 }

--- a/src/main/java/io/github/lounode/ae2cs/common/item/ResonatingPatternProviderPartItem.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/item/ResonatingPatternProviderPartItem.java
@@ -4,31 +4,9 @@ import io.github.lounode.ae2cs.common.me.part.ResonatingPatternProviderPart;
 
 import appeng.items.parts.PartItem;
 
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.UseOnContext;
-
-import org.jetbrains.annotations.NotNull;
-
-public class ResonatingPatternProviderPartItem extends PartItem<ResonatingPatternProviderPart> implements IResonatingTargetModeItem {
+public class ResonatingPatternProviderPartItem extends PartItem<ResonatingPatternProviderPart> {
 
     public ResonatingPatternProviderPartItem(Properties properties) {
         super(properties, ResonatingPatternProviderPart.class, ResonatingPatternProviderPart::new);
-    }
-
-    @Override
-    public @NotNull InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
-        return ResonatingProviderItemHelper.onItemUseFirst(stack, context);
-    }
-
-    @Override
-    public @NotNull InteractionResult useOn(UseOnContext context) {
-        return super.useOn(context);
-    }
-
-    @Override
-    public void scrollSelectedInputAndToast(Player player, ItemStack stack, boolean next) {
-        ResonatingProviderItemHelper.scrollSelectedInputAndToast(player, stack, next);
     }
 }

--- a/src/main/java/io/github/lounode/ae2cs/network/c2s/ResonatingLinkerBatchApplyPacket.java
+++ b/src/main/java/io/github/lounode/ae2cs/network/c2s/ResonatingLinkerBatchApplyPacket.java
@@ -1,0 +1,62 @@
+package io.github.lounode.ae2cs.network.c2s;
+
+import io.github.lounode.ae2cs.AE2CrystalScience;
+import io.github.lounode.ae2cs.common.item.ResonatingLinkerItem;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+import org.jetbrains.annotations.NotNull;
+
+public record ResonatingLinkerBatchApplyPacket(BlockPos pos, boolean mainHand, double hitX, double hitY, double hitZ) implements CustomPacketPayload {
+
+    public static final CustomPacketPayload.Type<ResonatingLinkerBatchApplyPacket> TYPE = new CustomPacketPayload.Type<>(AE2CrystalScience.makeId("resonating_linker_batch_apply_packet"));
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, ResonatingLinkerBatchApplyPacket> STREAM_CODEC = StreamCodec.composite(
+            BlockPos.STREAM_CODEC,
+            ResonatingLinkerBatchApplyPacket::pos,
+            ByteBufCodecs.BOOL,
+            ResonatingLinkerBatchApplyPacket::mainHand,
+            ByteBufCodecs.DOUBLE,
+            ResonatingLinkerBatchApplyPacket::hitX,
+            ByteBufCodecs.DOUBLE,
+            ResonatingLinkerBatchApplyPacket::hitY,
+            ByteBufCodecs.DOUBLE,
+            ResonatingLinkerBatchApplyPacket::hitZ,
+            ResonatingLinkerBatchApplyPacket::new);
+
+    @Override
+    public @NotNull Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    private void handleInServer(Player player) {
+        if (!(player instanceof ServerPlayer serverPlayer)) {
+            return;
+        }
+
+        InteractionHand hand = mainHand ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND;
+        var stack = serverPlayer.getItemInHand(hand);
+        if (!(stack.getItem() instanceof ResonatingLinkerItem)) {
+            return;
+        }
+
+        ResonatingLinkerItem.applyStoredTargetsToCluster(stack, serverPlayer, serverPlayer.level(), pos, new Vec3(hitX, hitY, hitZ));
+    }
+
+    public static void handle(ResonatingLinkerBatchApplyPacket packet, IPayloadContext context) {
+        context.enqueueWork(() -> {
+            if (context.flow().isServerbound()) {
+                packet.handleInServer(context.player());
+            }
+        });
+    }
+}


### PR DESCRIPTION
## 变更内容
- 将镜像和谐振供应器物品上的绑定交互迁移至对应绑定器。
- 镜像绑定器 Ctrl+右键仅批量应用到同类型且连通的镜像供应器。
- 为谐振绑定器新增 Ctrl+右键批量应用，并在服务端校验手持物品、距离和区块状态。

## 验证
- `./gradlew build`
- `./gradlew spotlessCheck`