### PR TITLE
补齐新增水晶配方

### DIFF
--- a/src/generated/resources/data/ae2cs/advancement/recipes/aggregator/data_crystal_seed.json
+++ b/src/generated/resources/data/ae2cs/advancement/recipes/aggregator/data_crystal_seed.json
@@ -1,0 +1,69 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "data_energistics"
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_input_0": {
+      "conditions": {
+        "items": [
+          {
+            "count": {
+              "min": 1
+            },
+            "items": "data_energistics:data_dust"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_input_1": {
+      "conditions": {
+        "items": [
+          {
+            "count": {
+              "min": 1
+            },
+            "items": "ae2:charged_certus_quartz_crystal"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_input_2": {
+      "conditions": {
+        "items": [
+          {
+            "count": {
+              "min": 1
+            },
+            "items": "minecraft:sand"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ae2cs:aggregator/data_crystal_seed"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_input_0",
+      "has_input_1",
+      "has_input_2"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ae2cs:aggregator/data_crystal_seed"
+    ]
+  }
+}

--- a/src/generated/resources/data/ae2cs/advancement/recipes/aggregator/energized_certus_quartz_seed.json
+++ b/src/generated/resources/data/ae2cs/advancement/recipes/aggregator/energized_certus_quartz_seed.json
@@ -1,0 +1,55 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_input_0": {
+      "conditions": {
+        "items": [
+          {
+            "count": {
+              "min": 1
+            },
+            "items": "neoecoae:energized_crystal"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_input_1": {
+      "conditions": {
+        "items": [
+          {
+            "count": {
+              "min": 1
+            },
+            "items": "minecraft:sand"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ae2cs:aggregator/energized_certus_quartz_seed"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_input_0",
+      "has_input_1"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ae2cs:aggregator/energized_certus_quartz_seed"
+    ]
+  }
+}

--- a/src/generated/resources/data/ae2cs/advancement/recipes/aggregator/energized_fluix_crystal_seed.json
+++ b/src/generated/resources/data/ae2cs/advancement/recipes/aggregator/energized_fluix_crystal_seed.json
@@ -1,0 +1,55 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_input_0": {
+      "conditions": {
+        "items": [
+          {
+            "count": {
+              "min": 1
+            },
+            "items": "neoecoae:energized_fluix_crystal"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_input_1": {
+      "conditions": {
+        "items": [
+          {
+            "count": {
+              "min": 1
+            },
+            "items": "minecraft:sand"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ae2cs:aggregator/energized_fluix_crystal_seed"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_input_0",
+      "has_input_1"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ae2cs:aggregator/energized_fluix_crystal_seed"
+    ]
+  }
+}

--- a/src/generated/resources/data/ae2cs/advancement/recipes/misc/craft/shapeless/data_crystal_seed.json
+++ b/src/generated/resources/data/ae2cs/advancement/recipes/misc/craft/shapeless/data_crystal_seed.json
@@ -1,0 +1,38 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "data_energistics"
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_data_dust": {
+      "conditions": {
+        "items": [
+          {
+            "items": "data_energistics:data_dust"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ae2cs:craft/shapeless/data_crystal_seed"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_data_dust"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ae2cs:craft/shapeless/data_crystal_seed"
+    ]
+  }
+}

--- a/src/generated/resources/data/ae2cs/advancement/recipes/misc/craft/shapeless/energized_certus_quartz_seed.json
+++ b/src/generated/resources/data/ae2cs/advancement/recipes/misc/craft/shapeless/energized_certus_quartz_seed.json
@@ -1,0 +1,38 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_energized_crystal": {
+      "conditions": {
+        "items": [
+          {
+            "items": "neoecoae:energized_crystal"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ae2cs:craft/shapeless/energized_certus_quartz_seed"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_energized_crystal"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ae2cs:craft/shapeless/energized_certus_quartz_seed"
+    ]
+  }
+}

--- a/src/generated/resources/data/ae2cs/advancement/recipes/misc/craft/shapeless/energized_fluix_crystal_seed.json
+++ b/src/generated/resources/data/ae2cs/advancement/recipes/misc/craft/shapeless/energized_fluix_crystal_seed.json
@@ -1,0 +1,38 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_energized_fluix_crystal": {
+      "conditions": {
+        "items": [
+          {
+            "items": "neoecoae:energized_fluix_crystal"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ae2cs:craft/shapeless/energized_fluix_crystal_seed"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_energized_fluix_crystal"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ae2cs:craft/shapeless/energized_fluix_crystal_seed"
+    ]
+  }
+}

--- a/src/generated/resources/data/ae2cs/advancement/recipes/pulverizer/data_dust_from_pure_data_crystal.json
+++ b/src/generated/resources/data/ae2cs/advancement/recipes/pulverizer/data_dust_from_pure_data_crystal.json
@@ -1,0 +1,41 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "data_energistics"
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_input_0": {
+      "conditions": {
+        "items": [
+          {
+            "count": {
+              "min": 1
+            },
+            "items": "ae2cs:purified_data_crystal"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ae2cs:pulverizer/data_dust_from_pure_data_crystal"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_input_0"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ae2cs:pulverizer/data_dust_from_pure_data_crystal"
+    ]
+  }
+}

--- a/src/generated/resources/data/ae2cs/advancement/recipes/pulverizer/energized_crystal_from_purified_energized_certus_quartz_crystal.json
+++ b/src/generated/resources/data/ae2cs/advancement/recipes/pulverizer/energized_crystal_from_purified_energized_certus_quartz_crystal.json
@@ -1,0 +1,41 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_input_0": {
+      "conditions": {
+        "items": [
+          {
+            "count": {
+              "min": 1
+            },
+            "items": "ae2cs:purified_energized_certus_quartz_crystal"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ae2cs:pulverizer/energized_crystal_from_purified_energized_certus_quartz_crystal"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_input_0"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ae2cs:pulverizer/energized_crystal_from_purified_energized_certus_quartz_crystal"
+    ]
+  }
+}

--- a/src/generated/resources/data/ae2cs/advancement/recipes/pulverizer/energized_fluix_crystal_from_purified_energized_fluix_crystal.json
+++ b/src/generated/resources/data/ae2cs/advancement/recipes/pulverizer/energized_fluix_crystal_from_purified_energized_fluix_crystal.json
@@ -1,0 +1,41 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_input_0": {
+      "conditions": {
+        "items": [
+          {
+            "count": {
+              "min": 1
+            },
+            "items": "ae2cs:purified_energized_fluix_crystal"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "ae2cs:pulverizer/energized_fluix_crystal_from_purified_energized_fluix_crystal"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_input_0"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "ae2cs:pulverizer/energized_fluix_crystal_from_purified_energized_fluix_crystal"
+    ]
+  }
+}

--- a/src/generated/resources/data/ae2cs/recipe/aggregator/data_crystal_seed.json
+++ b/src/generated/resources/data/ae2cs/recipe/aggregator/data_crystal_seed.json
@@ -1,0 +1,26 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "data_energistics"
+    }
+  ],
+  "type": "ae2cs:crystal_aggregator_recipe_serializer",
+  "energy_cost": 51200,
+  "input_a": {
+    "count": 8,
+    "item": "data_energistics:data_dust"
+  },
+  "input_b": {
+    "count": 8,
+    "item": "ae2:charged_certus_quartz_crystal"
+  },
+  "input_c": {
+    "count": 32,
+    "item": "minecraft:sand"
+  },
+  "result": {
+    "count": 32,
+    "id": "ae2cs:data_crystal_seed"
+  }
+}

--- a/src/generated/resources/data/ae2cs/recipe/aggregator/energized_certus_quartz_seed.json
+++ b/src/generated/resources/data/ae2cs/recipe/aggregator/energized_certus_quartz_seed.json
@@ -1,0 +1,22 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "type": "ae2cs:crystal_aggregator_recipe_serializer",
+  "energy_cost": 51200,
+  "input_a": {
+    "count": 8,
+    "item": "neoecoae:energized_crystal"
+  },
+  "input_b": {
+    "count": 32,
+    "item": "minecraft:sand"
+  },
+  "result": {
+    "count": 32,
+    "id": "ae2cs:energized_certus_quartz_seed"
+  }
+}

--- a/src/generated/resources/data/ae2cs/recipe/aggregator/energized_fluix_crystal_seed.json
+++ b/src/generated/resources/data/ae2cs/recipe/aggregator/energized_fluix_crystal_seed.json
@@ -1,0 +1,22 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "type": "ae2cs:crystal_aggregator_recipe_serializer",
+  "energy_cost": 51200,
+  "input_a": {
+    "count": 8,
+    "item": "neoecoae:energized_fluix_crystal"
+  },
+  "input_b": {
+    "count": 32,
+    "item": "minecraft:sand"
+  },
+  "result": {
+    "count": 32,
+    "id": "ae2cs:energized_fluix_crystal_seed"
+  }
+}

--- a/src/generated/resources/data/ae2cs/recipe/craft/shapeless/data_crystal_seed.json
+++ b/src/generated/resources/data/ae2cs/recipe/craft/shapeless/data_crystal_seed.json
@@ -1,0 +1,28 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "data_energistics"
+    }
+  ],
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    {
+      "item": "data_energistics:data_dust"
+    },
+    {
+      "item": "ae2:charged_certus_quartz_crystal"
+    },
+    {
+      "item": "minecraft:sand"
+    },
+    {
+      "item": "minecraft:sand"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "ae2cs:data_crystal_seed"
+  }
+}

--- a/src/generated/resources/data/ae2cs/recipe/craft/shapeless/energized_certus_quartz_seed.json
+++ b/src/generated/resources/data/ae2cs/recipe/craft/shapeless/energized_certus_quartz_seed.json
@@ -1,0 +1,25 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    {
+      "item": "neoecoae:energized_crystal"
+    },
+    {
+      "item": "minecraft:sand"
+    },
+    {
+      "item": "minecraft:sand"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "ae2cs:energized_certus_quartz_seed"
+  }
+}

--- a/src/generated/resources/data/ae2cs/recipe/craft/shapeless/energized_fluix_crystal_seed.json
+++ b/src/generated/resources/data/ae2cs/recipe/craft/shapeless/energized_fluix_crystal_seed.json
@@ -1,0 +1,25 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    {
+      "item": "neoecoae:energized_fluix_crystal"
+    },
+    {
+      "item": "minecraft:sand"
+    },
+    {
+      "item": "minecraft:sand"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "ae2cs:energized_fluix_crystal_seed"
+  }
+}

--- a/src/generated/resources/data/ae2cs/recipe/pulverizer/data_dust_from_pure_data_crystal.json
+++ b/src/generated/resources/data/ae2cs/recipe/pulverizer/data_dust_from_pure_data_crystal.json
@@ -1,0 +1,18 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "data_energistics"
+    }
+  ],
+  "type": "ae2cs:crystal_pulverizer_recipe_serializer",
+  "energy_cost": 8000,
+  "input": {
+    "count": 1,
+    "item": "ae2cs:purified_data_crystal"
+  },
+  "result": {
+    "count": 1,
+    "id": "data_energistics:data_dust"
+  }
+}

--- a/src/generated/resources/data/ae2cs/recipe/pulverizer/energized_crystal_from_purified_energized_certus_quartz_crystal.json
+++ b/src/generated/resources/data/ae2cs/recipe/pulverizer/energized_crystal_from_purified_energized_certus_quartz_crystal.json
@@ -1,0 +1,18 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "type": "ae2cs:crystal_pulverizer_recipe_serializer",
+  "energy_cost": 8000,
+  "input": {
+    "count": 1,
+    "item": "ae2cs:purified_energized_certus_quartz_crystal"
+  },
+  "result": {
+    "count": 1,
+    "id": "neoecoae:energized_crystal"
+  }
+}

--- a/src/generated/resources/data/ae2cs/recipe/pulverizer/energized_fluix_crystal_from_purified_energized_fluix_crystal.json
+++ b/src/generated/resources/data/ae2cs/recipe/pulverizer/energized_fluix_crystal_from_purified_energized_fluix_crystal.json
@@ -1,0 +1,18 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "neoecoae"
+    }
+  ],
+  "type": "ae2cs:crystal_pulverizer_recipe_serializer",
+  "energy_cost": 8000,
+  "input": {
+    "count": 1,
+    "item": "ae2cs:purified_energized_fluix_crystal"
+  },
+  "result": {
+    "count": 1,
+    "id": "neoecoae:energized_fluix_crystal"
+  }
+}

--- a/src/main/java/io/github/lounode/ae2cs/api/ids/AECSConstants.java
+++ b/src/main/java/io/github/lounode/ae2cs/api/ids/AECSConstants.java
@@ -14,5 +14,6 @@ public class AECSConstants {
     public static final String AF_ID = "appflux";
     public static final String CREATE_ID = "create";
     public static final String AE2LT_ID = "ae2lt";
+    public static final String DATA_ENERGISTICS_ID = "data_energistics";
     public static final String NEOECOAE_ID = "neoecoae";
 }

--- a/src/main/java/io/github/lounode/ae2cs/datagen/DataGenerators.java
+++ b/src/main/java/io/github/lounode/ae2cs/datagen/DataGenerators.java
@@ -95,6 +95,7 @@ public class DataGenerators {
         generator.addProvider(event.includeServer(), new AECSCompatAGRecipeProvider(packOutput, lookupProvider));
         generator.addProvider(event.includeServer(), new AECSCompatAE2LTRecipeProvider(packOutput, lookupProvider));
         generator.addProvider(event.includeServer(), new AECSCompatCreateRecipeProvider(packOutput, lookupProvider));
+        generator.addProvider(event.includeServer(), new AECSCompatDataEnergisticsRecipeProvider(packOutput, lookupProvider));
         generator.addProvider(event.includeServer(), new AECSCompatEAERecipeProvider(packOutput, lookupProvider));
         generator.addProvider(event.includeServer(), new AECSCompatMegaCellRecipeProvider(packOutput, lookupProvider));
         generator.addProvider(event.includeServer(), new AECSCompatMEKRecipeProvider(packOutput, lookupProvider));

--- a/src/main/java/io/github/lounode/ae2cs/datagen/recipes/compat/AECSCompatDataEnergisticsRecipeProvider.java
+++ b/src/main/java/io/github/lounode/ae2cs/datagen/recipes/compat/AECSCompatDataEnergisticsRecipeProvider.java
@@ -1,0 +1,65 @@
+package io.github.lounode.ae2cs.datagen.recipes.compat;
+
+import io.github.lounode.ae2cs.api.ids.AECSConstants;
+import io.github.lounode.ae2cs.common.init.AECSItems;
+import io.github.lounode.ae2cs.datagen.AECSRecipeProvider;
+import io.github.lounode.ae2cs.datagen.builder.recipe.CrystalAggregatorRecipeBuilder;
+import io.github.lounode.ae2cs.datagen.builder.recipe.CrystalPulverizerRecipeBuilder;
+
+import appeng.core.definitions.AEItems;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.recipes.RecipeCategory;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.ShapelessRecipeBuilder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Blocks;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * 为 DataEnergistics 的数据水晶补充谐振晶体生长链配方。
+ */
+public class AECSCompatDataEnergisticsRecipeProvider extends AECSRecipeProvider {
+
+    public AECSCompatDataEnergisticsRecipeProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
+        super(output, registries);
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return "AECS DataEnergistics Compat Recipes";
+    }
+
+    @Override
+    protected void buildRecipes(@NotNull RecipeOutput originalOut, HolderLookup.@NotNull Provider registries) {
+        RecipeOutput compatOut = originalOut.withConditions(modLoaded(AECSConstants.DATA_ENERGISTICS_ID));
+        Item dataDust = externalItem("data_dust");
+
+        ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, AECSItems.DATA_CRYSTAL_SEED)
+                .requires(dataDust)
+                .requires(AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED)
+                .requires(Blocks.SAND, 2)
+                .unlockedBy(getHasName(dataDust), has(dataDust))
+                .save(compatOut, getCrafterPath(AECSItems.DATA_CRYSTAL_SEED, false));
+
+        CrystalAggregatorRecipeBuilder.aggregating(AECSItems.DATA_CRYSTAL_SEED, 32, 51200)
+                .require(dataDust, 8)
+                .require(AEItems.CERTUS_QUARTZ_CRYSTAL_CHARGED, 8)
+                .require(Blocks.SAND, 32)
+                .save(compatOut, "aggregator/data_crystal_seed");
+
+        CrystalPulverizerRecipeBuilder.pulverizing(dataDust, 1, 8000)
+                .require(AECSItems.PURE_DATA_CRYSTAL, 1)
+                .save(compatOut, "pulverizer/data_dust_from_pure_data_crystal");
+    }
+
+    private static Item externalItem(String path) {
+        return BuiltInRegistries.ITEM.get(ResourceLocation.fromNamespaceAndPath(AECSConstants.DATA_ENERGISTICS_ID, path));
+    }
+}

--- a/src/main/java/io/github/lounode/ae2cs/datagen/recipes/compat/AECSCompatNeoECORecipeProvider.java
+++ b/src/main/java/io/github/lounode/ae2cs/datagen/recipes/compat/AECSCompatNeoECORecipeProvider.java
@@ -2,15 +2,21 @@ package io.github.lounode.ae2cs.datagen.recipes.compat;
 
 import io.github.lounode.ae2cs.api.ids.AECSConstants;
 import io.github.lounode.ae2cs.common.init.AECSBlocks;
+import io.github.lounode.ae2cs.common.init.AECSItems;
 import io.github.lounode.ae2cs.datagen.AECSRecipeProvider;
+import io.github.lounode.ae2cs.datagen.builder.recipe.CrystalAggregatorRecipeBuilder;
+import io.github.lounode.ae2cs.datagen.builder.recipe.CrystalPulverizerRecipeBuilder;
 
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.recipes.RecipeCategory;
 import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.ShapelessRecipeBuilder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Blocks;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +40,28 @@ public class AECSCompatNeoECORecipeProvider extends AECSRecipeProvider {
 
         packAndUnpack2x2(compatOut, RecipeCategory.MISC, RecipeCategory.MISC,
                 externalItem(AECSConstants.NEOECOAE_ID, "crystal_matrix"), AECSBlocks.PURE_CRYSTAL_GRID_BLOCK);
+
+        addCrystalGrowthRecipes(compatOut, AECSItems.ENERGIZED_FLUIX_CRYSTAL_SEED,
+                AECSItems.PURE_ENERGIZED_FLUIX_CRYSTAL, externalItem(AECSConstants.NEOECOAE_ID, "energized_fluix_crystal"));
+        addCrystalGrowthRecipes(compatOut, AECSItems.ENERGIZED_CERTUS_QUARTZ_SEED,
+                AECSItems.PURE_ENERGIZED_CERTUS_QUARTZ_CRYSTAL, externalItem(AECSConstants.NEOECOAE_ID, "energized_crystal"));
+    }
+
+    private static void addCrystalGrowthRecipes(RecipeOutput output, ItemLike seed, ItemLike pureCrystal, Item crystal) {
+        ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, seed)
+                .requires(crystal)
+                .requires(Blocks.SAND, 2)
+                .unlockedBy(getHasName(crystal), has(crystal))
+                .save(output, getCrafterPath(seed, false));
+
+        CrystalAggregatorRecipeBuilder.aggregating(seed, 32, 51200)
+                .require(crystal, 8)
+                .require(Blocks.SAND, 32)
+                .save(output, "aggregator/" + getItemName(seed));
+
+        CrystalPulverizerRecipeBuilder.pulverizing(crystal, 1, 8000)
+                .require(pureCrystal, 1)
+                .save(output, "pulverizer/" + getItemName(crystal) + "_from_" + getItemName(pureCrystal));
     }
 
     private static Item externalItem(String namespace, String path) {


### PR DESCRIPTION
## 变更内容
- 为数据水晶补充普通制种、晶能聚合制种与纯净水晶粉碎回收配方。
- 为盈能福鲁伊克斯水晶与盈能赛特斯水晶补充同样的完整生长配方链。
- 配方按 DataEnergistics 与 NeoEcoAE 的实际物品 ID 生成，并分别附带前置模组加载条件。
- 同步生成配方解锁进度。

## 验证
- ./gradlew runData
- ./gradlew build
- ./gradlew spotlessApply
- 核对生成 JSON 的前置条件与物品 ID。