### PR TITLE
补充镜像供应器组解绑

### DIFF
--- a/src/main/java/io/github/lounode/ae2cs/common/item/MirrorLinkerItem.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/item/MirrorLinkerItem.java
@@ -2,11 +2,13 @@ package io.github.lounode.ae2cs.common.item;
 
 import io.github.lounode.ae2cs.common.me.logic.MirrorPatternProviderHost;
 import io.github.lounode.ae2cs.common.me.logic.MirroredPatternProviderTarget;
+import io.github.lounode.ae2cs.util.ChunkHelper;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
@@ -40,7 +42,7 @@ public class MirrorLinkerItem extends Item {
     @Override
     public @NotNull InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
         Player player = context.getPlayer();
-        if (player == null || player.isShiftKeyDown()) {
+        if (player == null) {
             return InteractionResult.PASS;
         }
 
@@ -50,7 +52,16 @@ public class MirrorLinkerItem extends Item {
                 return InteractionResult.SUCCESS;
             }
 
+            if (player.isShiftKeyDown()) {
+                clearLoadedMirrorGroup(player, mirrorHost);
+                return InteractionResult.CONSUME;
+            }
+
             return applyStoredTarget(stack, player, mirrorHost) ? InteractionResult.CONSUME : InteractionResult.PASS;
+        }
+
+        if (player.isShiftKeyDown()) {
+            return InteractionResult.PASS;
         }
 
         return SimplePatternProviderMirrorHelper.tryBind(stack, context);
@@ -90,6 +101,33 @@ public class MirrorLinkerItem extends Item {
                     .withStyle(ChatFormatting.GRAY), true);
         }
         return true;
+    }
+
+    private static void clearLoadedMirrorGroup(Player player, MirrorPatternProviderHost selected) {
+        if (!(player.level() instanceof ServerLevel level)) {
+            return;
+        }
+
+        MirroredPatternProviderTarget target = selected.getMirroringLogic().getMirrorTarget();
+        if (target == null) {
+            player.displayClientMessage(Component.translatable("ae2cs.msg.mirror_linker.cleared_loaded_group", 0)
+                    .withStyle(ChatFormatting.GRAY), true);
+            return;
+        }
+
+        int cleared = 0;
+        for (var blockEntity : ChunkHelper.getLoadedBlockEntities(level)) {
+            for (MirrorPatternProviderHost host : PatternProviderBindingHelper.getMirrorProvidersAt(level, blockEntity.getBlockPos())) {
+                if (!target.equals(host.getMirroringLogic().getMirrorTarget())) {
+                    continue;
+                }
+                host.getMirroringLogic().setMirrorTarget(null);
+                cleared++;
+            }
+        }
+
+        player.displayClientMessage(Component.translatable("ae2cs.msg.mirror_linker.cleared_loaded_group", cleared)
+                .withStyle(ChatFormatting.GRAY), true);
     }
 
     public static int applyStoredTargetToCluster(ItemStack stack, Player player, Level level, BlockPos centerPos, Vec3 clickLocation) {

--- a/src/main/java/io/github/lounode/ae2cs/util/ChunkHelper.java
+++ b/src/main/java/io/github/lounode/ae2cs/util/ChunkHelper.java
@@ -1,14 +1,26 @@
 package io.github.lounode.ae2cs.util;
 
+import io.github.lounode.ae2cs.api.ids.AECSConstants;
+
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.level.ChunkEvent;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+@EventBusSubscriber(modid = AECSConstants.MODID)
 public class ChunkHelper {
+
+    private static final Map<ServerLevel, Set<Long>> LOADED_CHUNKS = new HashMap<>();
 
     /**
      * 在指定的已加载区块范围内收集所有的BE并进列表
@@ -24,5 +36,50 @@ public class ChunkHelper {
             }
         }
         return blockEntitiesInChunks;
+    }
+
+    /**
+     * Collects block entities from every fully loaded chunk in a dimension.
+     */
+    public static List<BlockEntity> getLoadedBlockEntities(ServerLevel level) {
+        List<BlockEntity> blockEntities = new ArrayList<>();
+        Set<Long> loadedChunks = LOADED_CHUNKS.get(level);
+        if (loadedChunks == null) {
+            return blockEntities;
+        }
+
+        for (long packedPos : loadedChunks) {
+            ChunkPos chunkPos = new ChunkPos(packedPos);
+            LevelChunk chunk = level.getChunkSource().getChunkNow(chunkPos.x, chunkPos.z);
+            if (chunk != null) {
+                blockEntities.addAll(chunk.getBlockEntities().values());
+            }
+        }
+        return blockEntities;
+    }
+
+    @SubscribeEvent
+    public static void onChunkLoad(ChunkEvent.Load event) {
+        if (!(event.getLevel() instanceof ServerLevel level) || !(event.getChunk() instanceof LevelChunk chunk)) {
+            return;
+        }
+        LOADED_CHUNKS.computeIfAbsent(level, ignored -> new HashSet<>()).add(chunk.getPos().toLong());
+    }
+
+    @SubscribeEvent
+    public static void onChunkUnload(ChunkEvent.Unload event) {
+        if (!(event.getLevel() instanceof ServerLevel level)) {
+            return;
+        }
+
+        Set<Long> loadedChunks = LOADED_CHUNKS.get(level);
+        if (loadedChunks == null) {
+            return;
+        }
+
+        loadedChunks.remove(event.getChunk().getPos().toLong());
+        if (loadedChunks.isEmpty()) {
+            LOADED_CHUNKS.remove(level);
+        }
     }
 }

--- a/src/main/resources/assets/ae2cs/lang/en_us.json
+++ b/src/main/resources/assets/ae2cs/lang/en_us.json
@@ -171,6 +171,7 @@
   "ae2cs.msg.mirror_linker.applied": "Applied the stored mirror target to the Mirror Pattern Provider",
   "ae2cs.msg.mirror_linker.applied_batch": "Applied the stored mirror target to %s nearby Mirror Pattern Providers",
   "ae2cs.msg.mirror_linker.cleared_batch": "Cleared the mirror target on %s nearby Mirror Pattern Providers",
+  "ae2cs.msg.mirror_linker.cleared_loaded_group": "Unbound %s loaded Mirror Pattern Providers in this binding group",
   "ae2cs.msg.mirror_linker.cleared_provider": "Cleared the mirror target on this Mirror Pattern Provider",
   "ae2cs.msg.mirror_pattern_provider.bound": "Bound mirror target to (%s, %s, %s)",
   "ae2cs.msg.mirror_pattern_provider.cleared": "Cleared mirror target",

--- a/src/main/resources/assets/ae2cs/lang/ja_jp.json
+++ b/src/main/resources/assets/ae2cs/lang/ja_jp.json
@@ -169,6 +169,7 @@
   "ae2cs.msg.mirror_linker.applied": "保存されたミラー対象をミラーパターンプロバイダーに適用しました",
   "ae2cs.msg.mirror_linker.applied_batch": "保存されたミラー対象を周囲の %s 個のミラーパターンプロバイダーに適用しました",
   "ae2cs.msg.mirror_linker.cleared_batch": "周囲の %s 個のミラーパターンプロバイダーのミラー対象を解除しました",
+  "ae2cs.msg.mirror_linker.cleared_loaded_group": "現在のディメンションで読み込み済みの同じグループのミラーパターンプロバイダー %s 個の紐付けを解除しました",
   "ae2cs.msg.mirror_linker.cleared_provider": "このミラーパターンプロバイダーのミラー対象を解除しました",
   "ae2cs.msg.mirror_pattern_provider.bound": "ミラー対象を (%s, %s, %s) にバインドしました",
   "ae2cs.msg.mirror_pattern_provider.cleared": "ミラー対象を解除しました",

--- a/src/main/resources/assets/ae2cs/lang/zh_cn.json
+++ b/src/main/resources/assets/ae2cs/lang/zh_cn.json
@@ -171,6 +171,7 @@
   "ae2cs.msg.mirror_linker.applied": "已将当前镜像目标写入镜像样板供应器",
   "ae2cs.msg.mirror_linker.applied_batch": "已将当前镜像目标写入附近的 %s 个镜像样板供应器",
   "ae2cs.msg.mirror_linker.cleared_batch": "已清空附近的 %s 个镜像样板供应器的镜像目标",
+  "ae2cs.msg.mirror_linker.cleared_loaded_group": "已解绑当前维度中已加载的 %s 个同组镜像样板供应器",
   "ae2cs.msg.mirror_linker.cleared_provider": "已清空该镜像样板供应器的镜像目标",
   "ae2cs.msg.mirror_pattern_provider.bound": "已绑定镜像目标到 (%s, %s, %s)",
   "ae2cs.msg.mirror_pattern_provider.cleared": "已清空镜像目标",


### PR DESCRIPTION
将镜像绑定器内的目标解绑与镜像样板供应器的绑定解绑分离。Shift 右键空气仅清除绑定器内目标；Shift 右键已绑定的镜像样板供应器时，按该供应器当前主目标解除当前维度所有已加载同组供应器的绑定。通过区块加载索引访问已加载区块，不会加载未加载区块，未加载供应器保留原绑定。补充中英日提示文本。验证：IDEA 增量编译通过，./gradlew.bat spotlessCheck 通过，游戏内实际测试通过。