### PR TITLE
补充 1.3.0 纹理与注册方案

### DIFF
--- a/docs/1.3.0-texture-and-registration-plan.md
+++ b/docs/1.3.0-texture-and-registration-plan.md
@@ -1,0 +1,156 @@
+# 1.3.0 纹理 ID 与注册实施说明
+
+本文根据 `寒冰的纹理/1.3.0/`、当前 AECS 资源结构与 AE2 的方块实体接入方式整理。它是实施规范，不会移动或重命名 `寒冰的纹理/` 中的源文件。
+
+## 约束与命名
+
+- 最终资源根目录固定为 `src/main/resources/assets/ae2cs/textures/`。
+- ID 使用全小写 `snake_case`，不使用中文、序号、哈希或展示名称。
+- 机器六面材质沿用 `block/<machine_id>/{on,off}/...`；普通方块和晶簇材质使用 `block/<resource_id>.png`；GUI 使用扁平的 `gui/<resource_id>.png`，物品使用 `item/<resource_id>.png`。
+- 机器菜单背景统一为 `gui/<machine_id>_menu.png`。菜单局部元素紧随机器 ID，例如 `gui/crystal_infuser_energy_slot.png`，不为 GUI 新建机器子目录。
+- 晶体族系沿用项目“材料名在前、物品类别在后”的风格：母岩为 `<material>_mother_rock`；四个标准阶段为 `<material>_small_crystal_bud`、`<material>_medium_crystal_bud`、`<material>_large_crystal_bud`、`<material>_crystal_cluster`；第五阶段为 `<material>_mature_crystal_cluster`。
+- `*_menu.png` 是完整 GUI 背景；`*_sheet.png` 是尚未拆分的图集，不能直接当作六面方块材质。
+- `16x96` 的母岩图为六帧竖向动画条。复制为 `<material>_mother_rock.png` 后必须补同名 `.mcmeta`，帧时长由美术确认，不能从源文件名推断。
+- 下文的晶簇阶段按照可见像素尺寸由小到大排序：`small_crystal_bud`、`medium_crystal_bud`、`large_crystal_bud`、`crystal_cluster`、`mature_crystal_cluster`。只有四个阶段时不注册 `<material>_mature_crystal_cluster`。
+
+## 机器纹理重命名
+
+当前 1.3.0 机器目录中没有任意一台机器的完整六面方块材质。`AECSBlockStateProvider.genSixFaceLike` 为可旋转机器要求 `bottom`、`top`、`front`、`back`、`left`、`right` 六张材质，`ACTIVE` 方块还要求 `on/`、`off/` 两套。因此本节把已提供图片定位为 GUI、图标、动画条或待拆分图集；缺少的方块面材质必须单独补齐，不能把 GUI 图片复用为方块面。
+
+| 来源目录 | 源文件 | 尺寸 | 建议最终 ID | 用途与结论 |
+| --- | --- | ---: | --- | --- |
+| 充能共振发电机 | `CB7AF132A3B1BDBE70EB141C69045B44.png` | 32x64 | `gui/charged_resonating_generator_sprite_sheet.png` | 小型图集，先保留为 GUI/精灵输入；需要模型定义后再切图。 |
+| 晶体注能器 | `4946049951AEE5C7D5CC1868982A3167.png` | 16x32 | `gui/crystal_infuser_vertical_meter.png` | 竖向双帧或双段量表。 |
+| 晶体注能器 | `5C004EDD1917131F3D3466C228AAAD81.png` | 16x16 | `gui/crystal_infuser_energy_slot.png` | GUI 槽位/能量元素。 |
+| 晶体注能器 | `745D2C23C69DE260A24C180288348821.png` | 16x16 | `gui/crystal_infuser_operation_slot.png` | GUI 槽位元素。 |
+| 晶体注能器 | `9E9EEED182B3828B3B54075A629CD69E.png` | 256x256 | `gui/crystal_infuser_menu.png` | 完整菜单背景。 |
+| 晶体注能器 | `BE5098FAD9CA51D88789271D6F6BFD61.png` | 16x32 | `gui/crystal_infuser_slot_frame.png` | 双段槽位边框。 |
+| 熵变反应室 | `9009C6689684EB2BEB1CF0F378FC9060.png` | 16x16 | `gui/entropy_variation_reaction_chamber_status_cold.png` | 蓝色状态图标。 |
+| 熵变反应室 | `C25847EA22F7EC205ACFAC2DA9A2BB38.png` | 16x16 | `gui/entropy_variation_reaction_chamber_status_hot.png` | 黄色状态图标。 |
+| 熵变反应室 | `F94E02CB5B37ED72F6DC1CD424EA3DB4.png` | 256x256 | `gui/entropy_variation_reaction_chamber_menu.png` | 完整菜单背景。 |
+| 粉碎工厂 | `4F2AED738EEF89522710CD6A5DD7D8E0.png` | 16x16 | `gui/crystal_pulverizer_crushing_chamber.png` | 粉碎腔静态元素。当前应复用现有 `crystal_pulverizer`，不要注册第二台同功能机器。 |
+| 粉碎工厂 | `6C0F375C5A94A58AF978A639ABC541F3.png` | 16x32 | `gui/crystal_pulverizer_crushing_chamber_animation.png` | 粉碎腔动画条。 |
+| 粉碎工厂 | `ACB786321B5EE2E74DE7322C1B964053.png` | 256x256 | `gui/crystal_pulverizer_menu.png` | 完整菜单背景。 |
+| 粉碎工厂 | `E4F47BA1D4744E6A0BC6CDFAA8D9398E.png` | 16x16 | `gui/crystal_pulverizer_progress_indicator.png` | 进度/端口元素。 |
+| 粉碎工厂 | `F2DCE7818B2F012CFBB10F50DC08404A.png` | 16x32 | `gui/crystal_pulverizer_progress_indicator_animation.png` | 进度动画条。 |
+| 聚合器 | `E1E15DDBA555DCE10F24D70279AF5726.png` | 256x256 | `gui/crystal_aggregator_menu.png` | 完整菜单背景。当前应复用现有 `crystal_aggregator`。 |
+| 脉冲离心机 | `7600A2F652E3FE001215181C8A8FE5DC.png` | 16x32 | `gui/pulse_centrifuge_rotor.png` | 转子或处理槽动画条。 |
+| 脉冲离心机 | `910C04902087FB205A71AA77D0D22A5F.png` | 16x192 | `gui/pulse_centrifuge_rotor_animation.png` | 12 帧竖向动画条。 |
+| 脉冲离心机 | `BF2E79F1D55BE71B129731CA81E53657.png` | 256x256 | `gui/pulse_centrifuge_menu.png` | 完整菜单背景。 |
+| 脉冲离心机 | `C5D2DD13D7DF7621C638E9E7EF633765.png` | 16x16 | `gui/pulse_centrifuge_slot_frame.png` | GUI 槽位边框。 |
+| 脉冲离心机 | `EEE10053704006890A047E46AE3733F8.png` | 16x16 | `gui/pulse_centrifuge_energy_indicator.png` | GUI 能量/状态元素。 |
+
+### 机器 ID 决策
+
+| 1.3.0 名称 | 代码/资源 ID | 注册决策 |
+| --- | --- | --- |
+| 充能共振发电机 | 待确认 | 先作为纹理源处理；确认是否替换 `crystal_vibration_chamber` 或新增机器后，才冻结注册 ID。 |
+| 晶体注能器 | 待确认 | 先作为纹理源处理；确认对应的现有机器或新玩法后，才冻结注册 ID。 |
+| 熵变反应室 | `entropy_variation_reaction_chamber` | 现有机器，仅替换/扩展 GUI 资源；不得重复注册。 |
+| 粉碎工厂 | `crystal_pulverizer` | 现有机器的展示名称或资源升级；保持现有注册 ID。 |
+| 聚合器 | `crystal_aggregator` | 现有机器，仅替换 GUI 资源。 |
+| 脉冲离心机 | 待确认 | 先作为纹理源处理；确认对应的现有机器或新玩法后，才冻结注册 ID。 |
+
+已确认的替换只修改相应资源路径、Screen 使用的 GUI 与本地化展示文本，不改 `AECSBlockIds`、`AECSBlocks`、`AECSBlockEntities`、菜单 ID、存档 NBT 键或配方类型。待确认的三项不得在确认前按“新机器”实施，也不得覆盖现有机器资源。
+
+## 母岩与晶簇纹理重命名
+
+下表中 `mother_rock` 是方块表面材质；阶段材质是有透明通道的晶簇模型材质。阶段列为避免重复而省略 `block/` 前缀和 `.png` 后缀，例如 `nether_quartz_small_crystal_bud` 表示 `block/nether_quartz_small_crystal_bud.png`。只有来源中确实存在的阶段才进入注册表。
+
+| 材料 ID | 母岩来源 -> 最终 ID | 晶簇来源，按成长顺序 -> 最终 ID |
+| --- | --- | --- |
+| `nether_quartz` | `CC1784E8CA407A26A0CF3E5A2E9F0F90` -> `block/nether_quartz_mother_rock.png` | `29B0EC1B0870AC6E933E9ADD24594379` -> `nether_quartz_small_crystal_bud`；`7F2F94676A5AA5CA51AB6FF6E0435F05` -> `nether_quartz_medium_crystal_bud`；`C5AD16A0F4B7F21D36DC01B3077F00D2` -> `nether_quartz_large_crystal_bud`；`CF7F524684B152D4443D8E754B52456B` -> `nether_quartz_crystal_cluster` |
+| `charged_certus_quartz` | `2F37E7D05834C73D4AF5DBFDA98FCD6C` -> `block/charged_certus_quartz_mother_rock.png`，动画 | `9C29CDD077A345C37AA94BF1F4F3B1F5` -> `charged_certus_quartz_small_crystal_bud`；`6B871E304821BFC964B1E8ED42BFEA12` -> `charged_certus_quartz_medium_crystal_bud`；`75CE68D78F4C9933FA3CB97AD375B294` -> `charged_certus_quartz_large_crystal_bud`；`5A6199E6A467D06298B2913FB91B6506` -> `charged_certus_quartz_crystal_cluster` |
+| `entro` | `236DF2D2C78F0706F7731F33808BE9C4` -> `block/entro_mother_rock.png` | 未提供晶簇阶段，不注册生长与掉落逻辑。 |
+| `ender_quartz` | `22C3BA8491957F434FA2954DFBC2BB74` -> `block/ender_quartz_mother_rock.png` | `DE72C0616671C344D5C3C6DF4B4C758C` -> `ender_quartz_small_crystal_bud`；`99FD8CFF1DF71142312699B9511B8C2C` -> `ender_quartz_medium_crystal_bud`；`A8B2239938086DEC5800A19F866C3C57` -> `ender_quartz_large_crystal_bud`；`81C19BB89108455812ECCCA0F160366E` -> `ender_quartz_crystal_cluster`；`D2805DAA4AF1D7852F0DC3124593C19F` -> `ender_quartz_mature_crystal_cluster` |
+| `energized_fluix` | `3EFB8D4BCF6A420354C0CF4D9C940E60` -> `block/energized_fluix_mother_rock.png`，动画 | `0BDE410A24863CB5BA0EFAB35BBDA6C7` -> `energized_fluix_small_crystal_bud`；`FDD6300952A438C3B2FC746EEDC59CF7` -> `energized_fluix_medium_crystal_bud`；`359EBFE61A5346FBAA093F184AD3687B` -> `energized_fluix_large_crystal_bud`；`FFFE7A5DEF534262822193391D44382A` -> `energized_fluix_crystal_cluster` |
+| `fluix` | `D1611863AE86A0D38995BC7949F66D92` -> `block/fluix_mother_rock.png` | `772743C40747B54D236785BFF90EEF50` -> `fluix_small_crystal_bud`；`9DFFF9FA23C12A736087168DBA1DA401` -> `fluix_medium_crystal_bud`；`9266018FD7E290B06A42B645C645BD50` -> `fluix_large_crystal_bud`；`CF63F768905C38DAEE4205608737ACF8` -> `fluix_crystal_cluster` |
+| `redstone` | `ACA6B7FEE1EE91E062EFCB9825C272D4` -> `block/redstone_mother_rock.png` | `0F7A255D7D37F9E8D35C6EF294351D27` -> `redstone_small_crystal_bud`；`9F5CEF6A2861E4554B5556C7AFD6D028` -> `redstone_medium_crystal_bud`；`0E8102CE81AFF9618244CF9B40EEDA34` -> `redstone_large_crystal_bud`；`2A04B92E6415D0629473E316B2DBC04B` -> `redstone_crystal_cluster` |
+| `resonating` | `9CDBD595DC65602EC7FA92AE989FCFB8` -> `block/resonating_mother_rock.png` | `86514123865DE2A72984EDEEE1D2BE5C` -> `resonating_small_crystal_bud`；`09032870B4B82F72795B6E6CA9A68CC7` -> `resonating_medium_crystal_bud`；`C3853B934E90F0A2895FD2A3415D7555` -> `resonating_large_crystal_bud`；`7295482FBAD5FC653CD57043830B4B50` -> `resonating_crystal_cluster`；`7CEE0E8EEFCA969492542A40202361F1` -> `resonating_mature_crystal_cluster` |
+| `quantum` | `13394C58A7E1542BB61F921E36D8DF3E` -> `block/quantum_mother_rock.png`，动画 | `2BA4EF0C5659AF2A070815B84286EC09` -> `quantum_small_crystal_bud`；`1AB76EE6A88E68951EE483DF7328F094` -> `quantum_medium_crystal_bud`；`354C8D483BA2A5E9C05BA31DD3BD4EAB` -> `quantum_large_crystal_bud`；`56707BAE611291A106A4E08CCED7663D` -> `quantum_crystal_cluster`；`ADCEF13E7973358AD5520946DEC1A3D4` -> `quantum_mature_crystal_cluster` |
+| `link` | `E706F1C92DD7216618A86E522820D614` -> `block/link_mother_rock.png` | `9701876774138C5D72D092FAFD1AAC9D` -> `link_small_crystal_bud`；`B20702690DD90DEF741F4D55E9EF5330` -> `link_medium_crystal_bud`；`19BBFD914AF3B58676C1974CE932E870` -> `link_large_crystal_bud`；`BB5480F760D6F4074D6F998DA67DFF3C` -> `link_crystal_cluster`；`CEA4A8FAA21A5984E87ECE8E62D67E28` -> `link_mature_crystal_cluster` |
+| `meteor` | `07D0D7770EAE28419CB6937F420BCDB0` -> `block/meteor_mother_rock.png` | `AEDFEB841602A2F9BA7AD9986B088901` -> `meteor_small_crystal_bud`；`731DDE58972E40C1C29E5AD410898BBD` -> `meteor_medium_crystal_bud`；`B0F2A0668735EE360F472B5C33E71135` -> `meteor_large_crystal_bud`；`F18AEBCABA1E7094CDAECDF05E20273D` -> `meteor_crystal_cluster`；`8F8D72421533ABA3D4CFA35499B1B80E` -> `meteor_mature_crystal_cluster` |
+
+表格内的阶段判断来自透明像素的可见范围。`link`、`ender_quartz`、`resonating`、`quantum`、`meteor` 具有第五个阶段；其游戏规则必须明确第五阶段是否可掉落、是否可继续生长，不能默认沿用四阶段材质。
+
+## 机器注册全流程
+
+以下流程以现有 `CrystalPulverizerBlock`、`CrystalPulverizerBlockEntity` 为模板，并使用 AE2 的 `AEBaseEntityBlock`、`AEBaseBlockEntity`、`MenuOpener`、`MenuLocators` 和 `MenuTypeBuilder` 接入方式。
+
+### 1. 先冻结注册与资源 ID
+
+1. 先确认每个目录是替换还是新增。只有确认“新增”后，才在 `AECSBlockIds` 添加对应机器常量；当前不得为充能共振发电机、晶体注能器、脉冲离心机预先注册 ID。
+2. 在 `AECSBlocks` 用 `registerOtherBlock` 注册方块；已有 `crystal_pulverizer`、`crystal_aggregator`、`entropy_variation_reaction_chamber` 只改资源，不新增 ID。
+3. 方块类继承 `AEBaseEntityBlock<...>`，按需求声明 `ACTIVE`、朝向与其他状态；机器交互通过 `useWithoutItem` 打开菜单，潜行时保留扳手/配置行为。
+4. 材质先落入 `textures/block/<machine_id>/`，完整 GUI 落入 `textures/gui/<machine_id>_menu.png`，不要让代码直接引用哈希名称。
+
+### 2. 服务端方块实体与 AE2 接入
+
+1. 建立 `<Machine>BlockEntity`，继承 `AENetworkedComponentBlockEntity` 或 `AENetworkedSelfPoweredBlockEntity`。需要 AE 能源、主节点、网络同步时优先复用后者。
+2. 在构造器中初始化库存、能量、升级与侧面配置组件；库存变化必须 `setChanged()`，状态改变必须同步并更新 `ACTIVE`。
+3. 配方执行使用现有配方类型与序列化器体系；新机器先在 `AECSRecipeTypes` 和 `AECSRecipeSerializers` 声明，再在 datagen 中生成配方 JSON。不要把配方判断塞入菜单或 Screen。
+4. 在 `AECSBlockEntities` 调用 `create(id, EntityClass, Constructor, AECSBlocks.BLOCK)`。该封装会绑定 BlockEntityType、AE 方块实体物品、以及 `ServerTickingBlockEntity`/`ClientTickingBlockEntity` 的 ticker。
+5. 需要保存的进度、配方 ID、库存、升级与自定义状态写入 `saveAdditional`/`loadTag`；重载后在 `onLoad` 恢复配方状态。
+6. 通过 `@ProvideCaps` 标记库存、能量或 AE 内部库存能力；`AECSCapabilities` 会据此批量注册 `IItemHandler`、`IEnergyStorage`、`GenericInternalInventory` 和 AE 网格节点能力。无法由通用逻辑表达的能力再在该类显式注册。
+
+### 3. 菜单、客户端界面与渲染
+
+1. 新建 `<Machine>Menu`，在 `AECSMenus` 使用 `MenuTypeBuilder.create` 注册同名菜单 ID。
+2. 新建 `<Machine>GUI` 或复用 AE2 的风格 Screen，在 `AECSScreens.registerScreens` 注册。GUI 背景引用本文件规定的 `gui/<machine_id>_menu.png`。
+3. GUI 图标、进度条和动画条必须使用已命名的局部资源；动画以 `.mcmeta` 或受控 UV 帧推进实现，不能依赖文件名中的帧序号。
+4. 只有显示内容超出普通方块模型或需要动态光效时，才增加 BlockEntityRenderer，并在 `AECSClientRenderers` 注册。普通六面方块不需要 BER。
+5. 更新 `en_us.json`、`zh_cn.json`、`ja_jp.json` 的方块、菜单、提示和 JEI/EMI 显示文本。
+
+### 4. 模型、数据与游戏内容
+
+1. 普通机器在 `AECSBlockStateProvider` 调用 `genSixFaceLike`。无 `ACTIVE` 状态时需要 `block/<id>/{bottom,top,front,back,left,right}.png`；有 `ACTIVE` 状态时需要 `block/<id>/off/` 和 `block/<id>/on/` 下各一套六面图。
+2. 如果机器不是立方体，提供手写 blockstate/model JSON，并让 item model 指向确定的展示模型；不要调用 `genSixFaceLike`。
+3. 在 `AECSBlockLootTableProvider` 明确机器掉落物、库存/升级返还和精准采集规则；机器有 BlockEntity 时同时验证拆除后的 NBT/附加掉落。
+4. 在 `AECSBlockTagProvider` 加入 `AECSTags.Blocks.AECS_MACHINE`、`BlockTags.MINEABLE_WITH_PICKAXE` 及必要的挖掘等级标签；有接口属性的机器按项目现有 `AECS_PART` 规则归类。
+5. 在 `AECSCraftRecipeProvider` 或专用配方 Provider 添加合成、加工、解锁与兼容配方；使用 `AECSRecipeProvider` 已注册的生成链路。
+6. 将方块/物品加入 `AECSCreativeModeTabs`；补 GuideME 页面与配方示例。
+7. `DataGenerators` 已统一注册 blockstate、loot、tag、recipe、worldgen Provider。运行数据生成后审阅 `src/generated/resources`，只提交与本次注册相关的输出。
+
+### 5. 验收顺序
+
+1. 先执行 `spotlessCheck compileJava`。
+2. 使用开发环境验证注册表、物品栏、方块放置、旋转、拆除与载入存档。
+3. 验证能源、物品能力和侧面配置；AE 网络节点与非 AE 自动化都应可见预期能力。
+4. 验证菜单服务端同步、GUI 动画、JEI/EMI 配方、升级和断电恢复。
+5. 最后运行 datagen、检查生成资源和语言缺失，再进行客户端与专用服务器烟雾测试。
+
+## 母岩与晶簇注册流程
+
+### 注册模型
+
+每种材料只注册两个玩家可见 ID：`<material>_mother_rock` 与 `<material>_crystal_cluster`。晶簇使用一个带 `AGE`、`FACING`、`WATERLOGGED` 的方块；未成熟阶段没有独立物品形式。这样可以避免把每个成长阶段注册为无意义的独立物品，也让第五阶段材料自然支持 `AGE=0..4`。
+
+1. 在 `AECSBlockIds` 增加母岩与晶簇 ID；为每一种实际提供了晶簇阶段的材料增加两个 ID。`entro` 在补齐晶簇贴图和掉落设计前仅注册母岩。
+2. 新建 `CrystalMotherRockBlock`：无 BlockEntity，支持随机 tick；在相邻可替换位置生成 `CrystalClusterBlock` 的 `AGE=0`、正确 `FACING` 与 `WATERLOGGED` 状态。
+3. 新建 `CrystalClusterBlock`：根据 `AGE` 提供碰撞箱/选择箱；随机 tick 或母岩 tick 推进阶段；成熟阶段由明确的掉落规则产出对应纯净水晶或晶簇物品。
+4. 不使用反射、全局扫描或未加载区块操作。生长只检查本方块与相邻已加载位置。
+5. 在 `AECSBlocks` 注册具体方块和方块物品；晶簇物品只绑定成熟状态对应的方块物品模型。母岩是否可获得由玩法决定，默认不放入创造栏。
+
+### 模型与数据生成
+
+1. 母岩使用 cube/cube_all 模型，引用 `block/<material>_mother_rock`。动画母岩补 `.mcmeta`，静态母岩不补动画文件。
+2. 晶簇使用朝向模型，按 `AGE` 切换 `<material>_small_crystal_bud` 至 `<material>_mature_crystal_cluster`；使用旋转后的模型变体处理六个附着面，不能把一张平面图直接作为立方体六面图。
+3. 为母岩和晶簇增加专用 `genCrystalFamily` 数据生成方法，而不是污染 `genSixFaceLike`。该方法生成 blockstate、年龄模型、朝向旋转和成熟物品模型。
+4. 在 `AECSBlockLootTableProvider` 处理：母岩默认掉自身或不掉落需显式决定；未成熟晶簇默认不掉落，成熟晶簇按精准采集/普通挖掘分别定义。所有分支都要处理爆炸衰减。
+5. 在 `AECSBlockTagProvider` 加入 `BlockTags.MINEABLE_WITH_PICKAXE` 与玩法要求的挖掘等级；如需要数据包扩展，新增 `aecs:mother_rocks`、`aecs:crystal_clusters` 标签。
+6. 只为成熟晶簇添加配方、战利品和物品模型；成长由方块逻辑驱动，不生成无用途的阶段物品配方。
+
+### 世界生成与兼容
+
+1. 若母岩只由配方/结构放置，不新增 worldgen。
+2. 若需要自然生成，按现有 `AECSConfiguredFeatures`、`AECSPlacedFeatures`、`AECSBiomeModifiers` 三层增加特征：先定义 Configured Feature，再定义高度、频率和生物群系过滤，最后通过 Biome Modifier 挂入生成步骤。
+3. 世界生成先从单一材料做数据包和性能验证，再扩展到其余材料；禁止在区块加载事件中手写生成。
+4. `charged_certus_quartz`、`fluix` 等与 AE2 已有材料重名的族系应只新增 AECS 母岩/晶簇方块，不能覆盖 AE2 原版物品或标签语义。
+
+## 实施前必须确认的缺口
+
+- 充能共振发电机、晶体注能器、脉冲离心机的注册归属尚未确认，且尚缺完整方块模型与六面材质；现有文件只能确定 GUI 资产。
+- `entro` 仅有母岩贴图，不能实现晶簇成长链。
+- 每种晶簇的成熟产物、掉落数量、精准采集规则、成长概率、第五阶段是否可继续成长尚未定义。
+- 动画母岩的帧时长和是否插帧需要由美术/玩法确认。
+- “粉碎工厂”“聚合器”“熵变反应室”是已有机器的纹理替换，保持现有注册 ID。其余三个目录在确认替换对象或新增玩法前不得注册。


### PR DESCRIPTION
## 说明

- 整理 1.3.0 哈希纹理到符合 AECS 现有资源结构的语义化 ID。
- 补充机器、母岩和晶簇从注册、数据生成到验证的完整实施流程。
- 明确熵变反应室、粉碎工厂和聚合器仅替换既有资源，不新增重复注册。

## 待确认项

- 充能共振发电机、晶体注能器和脉冲离心机在确认对应既有机器或新增玩法前不冻结注册 ID。
- 晶簇成熟掉落、成长概率、第五阶段规则和动画帧时长仍需由玩法与美术确认。