### PR TITLE
fix: 修复镜像重连与谐振残留状态

### DIFF
--- a/src/main/java/io/github/lounode/ae2cs/common/block/entity/MirrorPatternProviderBlockEntity.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/block/entity/MirrorPatternProviderBlockEntity.java
@@ -7,6 +7,7 @@ import io.github.lounode.ae2cs.common.me.logic.MirrorPatternProviderLogic;
 import io.github.lounode.ae2cs.common.me.logic.MirroredPatternProviderTarget;
 
 import appeng.api.AECapabilities;
+import appeng.api.networking.IGridNodeListener;
 import appeng.api.stacks.AEItemKey;
 import appeng.blockentity.crafting.PatternProviderBlockEntity;
 import appeng.helpers.patternprovider.PatternProviderLogic;
@@ -35,6 +36,12 @@ public class MirrorPatternProviderBlockEntity extends PatternProviderBlockEntity
     @Override
     protected PatternProviderLogic createLogic() {
         return new MirrorPatternProviderLogic(getMainNode(), this);
+    }
+
+    @Override
+    public void onMainNodeStateChanged(IGridNodeListener.State reason) {
+        super.onMainNodeStateChanged(reason);
+        getMirroringLogic().refreshMirroredPatternsAfterGridReconnect();
     }
 
     public static void onRegisterCaps(RegisterCapabilitiesEvent event) {

--- a/src/main/java/io/github/lounode/ae2cs/common/me/logic/MirrorPatternProviderLogic.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/me/logic/MirrorPatternProviderLogic.java
@@ -106,6 +106,27 @@ public class MirrorPatternProviderLogic extends PatternProviderLogic {
 
     @Override
     public void updatePatterns() {
+        updateMirroredPatterns(false);
+    }
+
+    /**
+     * Re-registers the mirrored patterns after this provider returns to an active grid.
+     *
+     * <p>
+     * AE2 removes a node's crafting-provider cache while rebuilding a grid. A mirror can keep the
+     * same pattern list across that transition, in which case {@link #updatePatterns()} correctly sees
+     * no content change but would otherwise skip the cache refresh.
+     * </p>
+     */
+    public void refreshMirroredPatternsAfterGridReconnect() {
+        if (!isMirroring() || !mainNode.isActive()) {
+            return;
+        }
+
+        updateMirroredPatterns(true);
+    }
+
+    private void updateMirroredPatterns(boolean forceCraftingProviderRefresh) {
         if (!isMirroring()) {
             super.updatePatterns();
             return;
@@ -118,6 +139,8 @@ public class MirrorPatternProviderLogic extends PatternProviderLogic {
                 patterns.clear();
                 patternInputs.clear();
                 ICraftingProvider.requestUpdate(mainNode);
+            } else if (forceCraftingProviderRefresh) {
+                ICraftingProvider.requestUpdate(mainNode);
             }
             return;
         }
@@ -125,6 +148,9 @@ public class MirrorPatternProviderLogic extends PatternProviderLogic {
         var targetPatterns = target.getLogic().getAvailablePatterns();
 
         if (patterns.equals(targetPatterns)) {
+            if (forceCraftingProviderRefresh) {
+                ICraftingProvider.requestUpdate(mainNode);
+            }
             return;
         }
 

--- a/src/main/java/io/github/lounode/ae2cs/common/me/logic/ResonatingPatternProviderLogic.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/me/logic/ResonatingPatternProviderLogic.java
@@ -81,6 +81,11 @@ public class ResonatingPatternProviderLogic extends PatternProviderLogic impleme
      */
     private final List<PendingSend> resonatingSendList = new ArrayList<>();
 
+    /**
+     * 是否已经记录过父类待发送队列缺失发送方向的异常状态。
+     */
+    private boolean invalidPendingSendStateLogged;
+
     private final IUpgradeInventory upgrades = UpgradeInventories.forMachine(AECSBlocks.RESONATING_PATTERN_PROVIDER_BLOCK, 1, this::onUpgradesChange);
 
     /**
@@ -703,6 +708,60 @@ public class ResonatingPatternProviderLogic extends PatternProviderLogic impleme
         return sendResonatingStacksOut();
     }
 
+    /**
+     * 回收父类待发送队列中丢失发送方向的原料。
+     *
+     * <p>
+     * AE2 在此状态下会在 {@link #doWork()} 内抛出异常。这里将原料放回当前 ME 网络；若网络没有
+     * 空间，则保留队列并跳过父类工作，等待后续 tick 重试。
+     * </p>
+     *
+     * @return 是否成功回收了至少一部分原料
+     */
+    private boolean recoverInvalidPendingSendState() {
+        if (sendDirection != null || sendList.isEmpty()) {
+            invalidPendingSendStateLogged = false;
+            return false;
+        }
+
+        if (!invalidPendingSendStateLogged) {
+            AE2CrystalScience.LOGGER.error(
+                    "Detected invalid pending-send state in resonating pattern provider at {}; attempting to return {} pending stack(s) to the ME network.",
+                    host.getBlockEntity().getBlockPos(),
+                    sendList.size());
+            invalidPendingSendStateLogged = true;
+        }
+
+        var networkStorage = mainNode.getGrid().getStorageService().getInventory();
+        boolean recovered = false;
+
+        for (var iterator = sendList.listIterator(); iterator.hasNext();) {
+            var pending = iterator.next();
+            var inserted = networkStorage.insert(pending.what(), pending.amount(), Actionable.MODULATE, actionSource);
+
+            if (inserted >= pending.amount()) {
+                iterator.remove();
+                recovered = true;
+            } else if (inserted > 0) {
+                iterator.set(new GenericStack(pending.what(), pending.amount() - inserted));
+                recovered = true;
+            }
+        }
+
+        if (recovered) {
+            saveChanges();
+        }
+
+        if (sendList.isEmpty()) {
+            invalidPendingSendStateLogged = false;
+            AE2CrystalScience.LOGGER.info(
+                    "Recovered invalid pending-send state in resonating pattern provider at {}.",
+                    host.getBlockEntity().getBlockPos());
+        }
+
+        return recovered;
+    }
+
     @Override
     public void addDrops(List<ItemStack> drops) {
         super.addDrops(drops);
@@ -731,7 +790,9 @@ public class ResonatingPatternProviderLogic extends PatternProviderLogic impleme
                 return TickRateModulation.SLEEP;
             }
 
-            boolean could = doWork() | doResonatingWork() | doPullWork();
+            boolean recoveredPendingSends = recoverInvalidPendingSendState();
+            boolean hasInvalidPendingSendState = sendDirection == null && !sendList.isEmpty();
+            boolean could = recoveredPendingSends | (!hasInvalidPendingSendState && doWork()) | doResonatingWork() | doPullWork();
             boolean has = hasWorkToDo() || hasResonatingWorkToDo() || isEnablePull();
 
             return has ? (could ? TickRateModulation.URGENT : TickRateModulation.SLOWER) : TickRateModulation.SLEEP;

--- a/src/main/java/io/github/lounode/ae2cs/common/me/part/MirrorPatternProviderPart.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/me/part/MirrorPatternProviderPart.java
@@ -7,6 +7,7 @@ import io.github.lounode.ae2cs.common.me.logic.MirrorPatternProviderLogic;
 import io.github.lounode.ae2cs.common.me.logic.MirroredPatternProviderTarget;
 
 import appeng.api.AECapabilities;
+import appeng.api.networking.IGridNodeListener;
 import appeng.api.parts.IPartItem;
 import appeng.api.parts.IPartModel;
 import appeng.api.parts.RegisterPartCapabilitiesEvent;
@@ -70,6 +71,12 @@ public class MirrorPatternProviderPart extends PatternProviderPart implements Mi
     @Override
     protected PatternProviderLogic createLogic() {
         return new MirrorPatternProviderLogic(getMainNode(), this);
+    }
+
+    @Override
+    public void onMainNodeStateChanged(IGridNodeListener.State reason) {
+        super.onMainNodeStateChanged(reason);
+        getMirroringLogic().refreshMirroredPatternsAfterGridReconnect();
     }
 
     @Override

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -15,6 +15,7 @@ protected appeng.helpers.patternprovider.PatternProviderLogic hasWorkToDo()Z
 protected appeng.helpers.patternprovider.PatternProviderLogic doWork()Z
 protected appeng.helpers.patternprovider.PatternProviderLogic patternInputs
 protected appeng.helpers.patternprovider.PatternProviderLogic sendDirection
+protected appeng.helpers.patternprovider.PatternProviderLogic sendList
 protected appeng.helpers.patternprovider.PatternProviderLogic addToSendList(Lappeng/api/stacks/AEKey;J)V
 protected appeng.helpers.patternprovider.PatternProviderLogic onPushPatternSuccess(Lappeng/api/crafting/IPatternDetails;)V
 protected appeng.helpers.patternprovider.PatternProviderLogic sendStacksOut()Z


### PR DESCRIPTION
## 修复内容
- 镜像样板供应器重新获得活动网格后，强制刷新 AE2 crafting provider 缓存。
- 即使镜像目标的样板列表与断线前相同，也会重新登记，避免供应器显示或表现为无连接。
- 同时覆盖方块版与总线部件版镜像样板供应器。
- 修复谐振样板供应器的残留待发送状态：当 AE2 待发送队列非空但发送方向缺失时，不再调用会抛异常的父类发送逻辑。
- 异常队列中的原料会逐项退回当前 ME 网络；网络空间不足时保留队列并在后续 tick 重试，避免丢物和服务端崩溃。

## 验证
- IDEA 定向编译成功。
- `./gradlew.bat spotlessCheck test` 成功（项目当前无测试源码）。
- `./gradlew.bat compileJava --rerun-tasks` 成功。