### PR TITLE
fix: 修复末影设备重进存档后断联

### DIFF
--- a/src/main/java/io/github/lounode/ae2cs/common/block/EnderEmitterBlock.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/block/EnderEmitterBlock.java
@@ -106,6 +106,9 @@ public class EnderEmitterBlock extends AEBaseEntityBlock<EnderEmitterBlockEntity
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
         if (!level.isClientSide && state.is(this) && !newState.is(this)) {
+            if (state.getValue(BlockStateProperties.DOUBLE_BLOCK_HALF) == DoubleBlockHalf.LOWER && level.getBlockEntity(pos) instanceof EnderEmitterBlockEntity be) {
+                be.cleanConnectionPermanent();
+            }
             removeOtherHalfNoDrops(level, pos, state);
         }
         super.onRemove(state, level, pos, newState, movedByPiston);

--- a/src/main/java/io/github/lounode/ae2cs/common/block/entity/EnderBroadcasterBlockEntity.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/block/entity/EnderBroadcasterBlockEntity.java
@@ -493,15 +493,6 @@ public class EnderBroadcasterBlockEntity extends AENetworkedComponentBlockEntity
     }
 
     /**
-     * 方块被移除时，永久注销其在频段中的发送端或接收端身份。
-     */
-    @Override
-    public void setRemoved() {
-        cleanConnectionPermanent();
-        super.setRemoved();
-    }
-
-    /**
      * 网络初始化完成，恢复declared并上线
      */
     @Override

--- a/src/main/java/io/github/lounode/ae2cs/common/block/entity/EnderEmitterBlockEntity.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/block/entity/EnderEmitterBlockEntity.java
@@ -541,9 +541,8 @@ public class EnderEmitterBlockEntity extends AENetworkedBlockEntity implements S
 
     @Override
     public void setRemoved() {
-        cleanConnectionPermanent();
         super.setRemoved();
-        // 方块被移除时从全局索引移除
+        // BE被移除时从运行时索引移除
         if (level != null && !level.isClientSide()) {
             ChunkPos center = new ChunkPos(worldPosition);
             BlockPos posKey = worldPosition.immutable();


### PR DESCRIPTION
## 修改
- 区块卸载时保留末影广播装置和末影发信器的持久频段身份
- 末影发信器仅在下半方块真正移除时执行永久注销
- 保留方块实体移除时的运行时索引清理

## 验证
- IntelliJ IDEA 增量编译
- .\gradlew.bat spotlessCheck compileJava