### PR TITLE
兼容样板磁盘：自装配式样板供应器样样板槽支持样板磁盘（一槽二用）

### DIFF
--- a/src/main/java/io/github/lounode/ae2cs/common/block/entity/MeteoritePatternProviderBlockEntity.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/block/entity/MeteoritePatternProviderBlockEntity.java
@@ -3,6 +3,7 @@ package io.github.lounode.ae2cs.common.block.entity;
 import io.github.lounode.ae2cs.common.init.AECSBlockEntities;
 import io.github.lounode.ae2cs.common.init.AECSBlocks;
 import io.github.lounode.ae2cs.common.init.AECSMenus;
+import io.github.lounode.ae2cs.common.me.logic.DisksMeteoritePatternProviderLogic;
 import io.github.lounode.ae2cs.common.me.logic.MeteoritePatternProviderHost;
 import io.github.lounode.ae2cs.common.me.logic.MeteoritePatternProviderLogic;
 
@@ -29,7 +30,22 @@ public class MeteoritePatternProviderBlockEntity extends PatternProviderBlockEnt
 
     @Override
     protected PatternProviderLogic createLogic() {
-        return new MeteoritePatternProviderLogic(getMainNode(), this, 63);
+        return new DisksMeteoritePatternProviderLogic(getMainNode(), this, 63);
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        refreshFromDisks();
+    }
+
+    /**
+     * Re-syncs expanded disk recipes from the pattern inventory (AE2 Pattern Disk addon compatibility).
+     */
+    public void refreshFromDisks() {
+        if (getLogic() instanceof DisksMeteoritePatternProviderLogic diskLogic) {
+            diskLogic.refreshPatternsFromDisks();
+        }
     }
 
     /**

--- a/src/main/java/io/github/lounode/ae2cs/common/me/logic/DisksMeteoritePatternProviderLogic.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/me/logic/DisksMeteoritePatternProviderLogic.java
@@ -1,0 +1,158 @@
+package io.github.lounode.ae2cs.common.me.logic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.neoforged.fml.ModList;
+
+import appeng.api.crafting.IPatternDetails;
+import appeng.api.crafting.PatternDetailsHelper;
+import appeng.api.inventories.InternalInventory;
+import appeng.api.networking.IManagedGridNode;
+
+import io.github.lounode.ae2cs.common.block.entity.MeteoritePatternProviderBlockEntity;
+
+/**
+ * A {@link MeteoritePatternProviderLogic} whose available patterns are the union of vanilla patterns and
+ * expanded <b>pattern disks</b> (AE2 Pattern Disk addon) — the "one slot, two uses" approach.
+ *
+ * <p><b>Sealed contract:</b> AECS carries its own copy of the disk content format ({@link DiskContents}).
+ * The addon's {@code ae2_pattern_disk:disk_contents} data component value is read via the component's own
+ * codec (encode to NBT, then decode with our format copy) — no reflective calls, no class dependency. The
+ * two mods only share the <i>formats</i> ({@code type}/{@code capacity}/{@code patterns}), so either side
+ * may evolve its parsing independently.</p>
+ *
+ * <p>The disk algorithm is active only when the addon is loaded ({@link #isAddonLoaded()}); otherwise the
+ * provider behaves exactly like the vanilla one.</p>
+ */
+public class DisksMeteoritePatternProviderLogic extends MeteoritePatternProviderLogic {
+
+    private static final ResourceLocation DISK_CONTENTS_ID = ResourceLocation.parse("ae2_pattern_disk:disk_contents");
+
+    /** Contract copy of the addon's disk content format. */
+    public record DiskContents(String type, int capacity, List<ItemStack> patterns) {
+        public static final Codec<DiskContents> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+                Codec.STRING.optionalFieldOf("type").forGetter(c -> Optional.ofNullable(c.type)),
+                Codec.INT.fieldOf("capacity").forGetter(DiskContents::capacity),
+                ItemStack.OPTIONAL_CODEC.listOf().fieldOf("patterns").forGetter(DiskContents::patterns))
+                .apply(instance, (type, capacity, patterns) -> new DiskContents(type.orElse(null), capacity, patterns)));
+    }
+
+    private final List<ItemStack> diskPatterns = new ArrayList<>();
+    private final MeteoritePatternProviderBlockEntity host;
+
+    public DisksMeteoritePatternProviderLogic(
+            IManagedGridNode mainNode,
+            MeteoritePatternProviderBlockEntity host,
+            int patternInventorySize) {
+        super(mainNode, host, patternInventorySize);
+        this.host = host;
+    }
+
+    private static boolean isAddonLoaded() {
+        return ModList.get().isLoaded("ae2_pattern_disk");
+    }
+
+    /**
+     * Re-scans the parent pattern inventory for pattern disks and refreshes expanded disk recipes.
+     * Vanilla patterns are untouched.
+     */
+    public void refreshPatternsFromDisks() {
+        diskPatterns.clear();
+        if (!isAddonLoaded()) {
+            return;
+        }
+        InternalInventory patternInv = getPatternInv();
+        if (patternInv == null) {
+            return;
+        }
+        for (int i = 0; i < patternInv.size(); i++) {
+            DiskContents contents = readDiskContents(patternInv.getStackInSlot(i));
+            if (contents != null) {
+                diskPatterns.addAll(contents.patterns());
+            }
+        }
+        updatePatterns();
+    }
+
+    /**
+     * Reads the addon disk's content via the component's own codec (encode the value object to NBT, then
+     * decode with our {@link DiskContents#CODEC} format copy). Returns {@code null} if not a pattern disk.
+     */
+    private DiskContents readDiskContents(ItemStack stack) {
+        if (stack == null || stack.isEmpty() || !isAddonLoaded()) {
+            return null;
+        }
+        DataComponentType<?> type = BuiltInRegistries.DATA_COMPONENT_TYPE.get(DISK_CONTENTS_ID);
+        if (type == null) {
+            return null;
+        }
+        Object value = stack.getComponents().get(type);
+        if (value == null) {
+            return null;
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            var valueCodec = (Codec<Object>) ((DataComponentType<?>) type).codec();
+            var encoded = valueCodec.encodeStart(NbtOps.INSTANCE, value).result();
+            if (encoded.isEmpty()) {
+                return null;
+            }
+            return DiskContents.CODEC.decode(NbtOps.INSTANCE, encoded.get()).result()
+                    .map(pair -> pair.getFirst()).orElse(null);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Merged patterns: parent-decoded vanilla patterns + expanded disk recipes. */
+    @Override
+    public List<IPatternDetails> getAvailablePatterns() {
+        List<IPatternDetails> result = new ArrayList<>(super.getAvailablePatterns());
+        if (!isAddonLoaded()) {
+            return result;
+        }
+        // Lazily re-scan the pattern inventory for the latest disk recipes so the terminal always sees
+        // patterns added at runtime (the inventory-onChange path does not re-trigger our refresh).
+        reScanCurrentDisks();
+        Level level = host == null ? null : host.getBlockEntity().getLevel();
+        if (level == null) {
+            return result;
+        }
+        for (ItemStack pattern : diskPatterns) {
+            IPatternDetails details = PatternDetailsHelper.decodePattern(pattern, level);
+            if (details != null) {
+                result.add(details);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Re-reads pattern disks currently in the parent pattern inventory into {@link #diskPatterns}.
+     * Does not touch the parent's pattern list; we only refresh our expanded disk recipes cache.
+     */
+    private void reScanCurrentDisks() {
+        diskPatterns.clear();
+        InternalInventory patternInv = getPatternInv();
+        if (patternInv == null) {
+            return;
+        }
+        for (int i = 0; i < patternInv.size(); i++) {
+            DiskContents contents = readDiskContents(patternInv.getStackInSlot(i));
+            if (contents != null) {
+                diskPatterns.addAll(contents.patterns());
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/lounode/ae2cs/common/menu/UpgradeablePatternProviderMenu.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/menu/UpgradeablePatternProviderMenu.java
@@ -55,8 +55,7 @@ public class UpgradeablePatternProviderMenu extends AEBaseMenu {
 
         var patternInv = logic.getPatternInv();
         for (int x = 0; x < patternInv.size(); x++) {
-            this.addSlot(new RestrictedInputSlot(RestrictedInputSlot.PlacableItemType.PROVIDER_PATTERN,
-                    patternInv, x),
+            this.addSlot(new DiskAwarePatternSlot(patternInv, x),
                     SlotSemantics.ENCODED_PATTERN);
         }
 
@@ -114,5 +113,38 @@ public class UpgradeablePatternProviderMenu extends AEBaseMenu {
             return upgradeableLogic.getUpgrades();
         else
             return UpgradeInventories.empty();
+    }
+
+    /**
+     * Pattern slot that accepts either a vanilla encoded pattern (AE2) or a pattern disk (AE2 Pattern Disk
+     * addon) — the "one slot, two uses" behavior. Disk detection is reflective to avoid a hard
+     * compile-time dependency on the addon.
+     */
+    private static class DiskAwarePatternSlot extends appeng.menu.slot.AppEngSlot
+    {
+        DiskAwarePatternSlot(appeng.api.inventories.InternalInventory inv, int index)
+        {
+            super(inv, index);
+        }
+
+        @Override
+        public boolean mayPlace(net.minecraft.world.item.ItemStack stack)
+        {
+            if (stack == null || stack.isEmpty())
+                return false;
+            // Accept vanilla patterns.
+            if (appeng.api.crafting.PatternDetailsHelper.isEncodedPattern(stack))
+                return true;
+            // Accept pattern disks (reflective check for the addon's `contents(ItemStack)` method).
+            try
+            {
+                stack.getItem().getClass().getMethod("contents", net.minecraft.world.item.ItemStack.class);
+                return true;
+            }
+            catch (NoSuchMethodException e)
+            {
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
## 需求
本补丁为「自装配式样板供应器」（meteorite_pattern_provider）增加对样板磁盘（AE2 Pattern Disk 附属）的支持，实现样样板槽「一槽二用」——同一样样板槽既放置普通样板，也可放置样板磁盘，磁盘内的配方会被展开参与自动合成。

## 改动
1. **新增 `DisksMeteoritePatternProviderLogic`**（继承自装配 logic）：
   - 从样板磁盘展开配方（仅当 `ModList.isLoaded("ae2_pattern_disk")` 时启用，未装则退化为纯普通样板行为）
   - 磁盘内容通过「组件自身 Codec 编解码 + 本 mod 内置格式副本」读取——无运行时反射、无类依赖，双方只共享 `type/capacity/patterns` 格式契约
   - 保留自装配产物回送逻辑（craftedContents / Ticker 继承不动）
2. **`MeteoritePatternProviderBlockEntity`**：
   - `createLogic` 改用磁盘 logic
   - 新增 `onLoad` / `refreshFromDisks` 刷新磁盘配方
3. **`UpgradeablePatternProviderMenu`**：
   - 样样板槽改用 `DiskAwarePatternSlot`：同槽既可放普通样板也可放样板磁盘（反射式判定磁盘物品）

## 关键设计
- **一槽二用**：普通样板与样板磁盘共存于原版样样板槽，`getAvailablePatterns` 合并两者，共同参与自动合成
- **可分离修订**：两 mod 只共享格式契约（type/capacity/patterns），各自实现解析，互不依赖
- **非反射即时运算**：磁盘读取走 Codec 编解码域，无 getMethod/invoke

## 测试
- 两 mod 同装（AE2 Crystal Science + AE2 Pattern Disk）加载正常
- 自装配式样板供应器可放置、BE 数据正常
- 待人工验证：样样板槽放置样板磁盘后配方被展开到管理终端

请在合并前验证兼容性，若有调整欢迎反馈。