### PR TITLE
fix: 修复谐振终端通用终端合成、快捷键翻译与锻造台消耗

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,15 @@ sourceSets {
         compileClasspath += client.output + extra.compileClasspath
         runtimeClasspath += client.output + client.runtimeClasspath + extra.runtimeClasspath
     }
+
+    jeiClient {
+        compileClasspath += clientExtra.compileClasspath
+        runtimeClasspath += clientExtra.runtimeClasspath.filter { file ->
+            def name = file.name.toLowerCase()
+            !(name.startsWith('emi-') || name.contains('-emi-')
+                    || name.contains('jei-1.21.1-neoforge') || name.contains('jei-1.21.1-common'))
+        }
+    }
 }
 
 configurations {
@@ -65,7 +74,13 @@ configurations {
     renderNurseCfg {
         canBeConsumed = false
     }
+
+    jeiClientRuntime {
+        canBeConsumed = false
+    }
 }
+
+sourceSets.jeiClient.runtimeClasspath += configurations.jeiClientRuntime
 
 apply from: "$rootDir/gradle/scripts/jars.gradle"
 apply from: "$rootDir/gradle/scripts/moddevgradle.gradle"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -92,6 +92,9 @@ dependencies {
     implementation "curse.maven:applied-generators-1320369:7161908"
     // OMNI CELL
     implementation "curse.maven:omni-cells-1359517:7169530"
+    localRuntime "curse.maven:cognition-mod-579484:8406272"
+    localRuntime "maven.modrinth:xv94TkTM:FaNppCJJ"
+    localRuntime "maven.modrinth:fuuu3xnx:iEE85X0w"
 
     // Client-only runtime mods
     clientLocalRuntime(forge.jech)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -95,6 +95,8 @@ dependencies {
     localRuntime "curse.maven:cognition-mod-579484:8406272"
     localRuntime "maven.modrinth:xv94TkTM:FaNppCJJ"
     localRuntime "maven.modrinth:fuuu3xnx:iEE85X0w"
+    localRuntime "curse.maven:forbidden-arcanus-309858:6875895"
+    localRuntime "curse.maven:valhelsia-core-416935:6296775"
 
     // Client-only runtime mods
     clientLocalRuntime(forge.jech)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    def enableEmi = providers.gradleProperty("enableEmi").map(String::toBoolean).orElse(false).get()
+    def enableEmi = providers.gradleProperty("enableEmi").map { it.toBoolean() }.orElse(false).get()
 
     compileOnly(libs.jetbrains.annotations)
 
@@ -36,6 +36,7 @@ dependencies {
 
     // Recipe viewers
     compileOnly(forge.bundles.jei)
+    compileOnly "curse.maven:jei-238222:8759217"
     compileOnly(forge.emi)
 
     // WAILA-likes
@@ -83,10 +84,7 @@ dependencies {
     localRuntime(forge.amek)
     localRuntime(forge.mek)
 
-    // Runtime recipe viewers
-    if (enableEmi) {
-        localRuntime(forge.emi)
-    }
+    // Runtime recipe viewers. EMI is attached only to All Client runs.
     localRuntime(forge.jei.neoforge.impl)
     // AG
     implementation "curse.maven:applied-generators-1320369:7161908"
@@ -97,6 +95,8 @@ dependencies {
     localRuntime "maven.modrinth:fuuu3xnx:iEE85X0w"
     localRuntime "curse.maven:forbidden-arcanus-309858:6875895"
     localRuntime "curse.maven:valhelsia-core-416935:6296775"
+    localRuntime "curse.maven:imblocker-483760:8167852"
+    jeiClientRuntime "curse.maven:jei-238222:8759217"
 
     // Client-only runtime mods
     clientLocalRuntime(forge.jech)

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -1,0 +1,1 @@
+toolchainVersion=21

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 minecraft = "1.21.1"
-neoForge = "21.1.216"
+neoForge = "21.1.238"
 loader = "4"
 parchment = "2024.11.17" # https://parchmentmc.org/docs/getting-started
 shadow = "9.4.0"

--- a/gradle/scripts/moddevgradle.gradle
+++ b/gradle/scripts/moddevgradle.gradle
@@ -16,6 +16,7 @@ neoForge {
 
     addModdingDependenciesTo(sourceSets.test)
     addModdingDependenciesTo(sourceSets.extra)
+    addModdingDependenciesTo(sourceSets.jeiClient)
 
     mods {
         // define mod <-> source bindings
@@ -24,7 +25,6 @@ neoForge {
             sourceSet(sourceSets.client)
             sourceSet(sourceSets.test)
             sourceSet(sourceSets.extra)
-            sourceSet(sourceSets.clientExtra)
         }
     }
 
@@ -37,6 +37,9 @@ neoForge {
 
             gameDirectory.set(file('run/all/client'))
             systemProperty('neoforge.enabledGameTestNamespaces', project.mod_id)
+            if (providers.gradleProperty("enableEmi").map { it.toBoolean() }.orElse(false).get()) {
+                project.dependencies.add(additionalRuntimeClasspathConfiguration.name, forge.emi)
+            }
         }
 
         server {
@@ -57,6 +60,9 @@ neoForge {
 
             gameDirectory.set(file('run/login/client'))
             systemProperty('neoforge.enabledGameTestNamespaces', project.mod_id)
+            if (providers.gradleProperty("enableEmi").map { it.toBoolean() }.orElse(false).get()) {
+                project.dependencies.add(additionalRuntimeClasspathConfiguration.name, forge.emi)
+            }
         }
 
         loginserver {
@@ -66,6 +72,15 @@ neoForge {
 
             gameDirectory.set(file('run/login/server'))
             programArguments.addAll('--nogui', '--world', 'world-extra')
+            systemProperty('neoforge.enabledGameTestNamespaces', project.mod_id)
+        }
+
+        clientJEI {
+            client()
+            sourceSet = sourceSets.jeiClient
+            ideName = "Client JEI"
+
+            gameDirectory.set(file('run/jei/client'))
             systemProperty('neoforge.enabledGameTestNamespaces', project.mod_id)
         }
 

--- a/src/generated/resources/data/ae2cs/recipe/wireless_universal_terminal_combine.json
+++ b/src/generated/resources/data/ae2cs/recipe/wireless_universal_terminal_combine.json
@@ -1,0 +1,4 @@
+{
+  "type": "ae2cs:wireless_universal_terminal_combine",
+  "category": "misc"
+}

--- a/src/main/java/io/github/lounode/ae2cs/common/init/AECSRecipeSerializers.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/init/AECSRecipeSerializers.java
@@ -3,6 +3,7 @@ package io.github.lounode.ae2cs.common.init;
 import io.github.lounode.ae2cs.api.ids.AECSConstants;
 import io.github.lounode.ae2cs.common.recipe.ResonatingLinkerClearRecipe;
 import io.github.lounode.ae2cs.common.recipe.ResonatingPatternUpgradeRecipe;
+import io.github.lounode.ae2cs.common.recipe.WirelessUniversalTerminalCombineRecipe;
 import io.github.lounode.ae2cs.common.recipe.circuit_etcher.CircuitEtcherRecipe;
 import io.github.lounode.ae2cs.common.recipe.circuit_etcher.CircuitEtcherRecipeSerializer;
 import io.github.lounode.ae2cs.common.recipe.crystal_aggregator.CrystalAggregatorRecipe;
@@ -39,6 +40,8 @@ public class AECSRecipeSerializers {
     public static final Supplier<RecipeSerializer<ResonatingPatternUpgradeRecipe>> RESONATING_PATTERN_UPGRADE = RECIPE_SERIALIZERS.register("resonating_pattern_upgrade", () -> new SimpleCraftingRecipeSerializer<>(ResonatingPatternUpgradeRecipe::new));
 
     public static final Supplier<RecipeSerializer<ResonatingLinkerClearRecipe>> RESONATING_LINKER_CLEAR = RECIPE_SERIALIZERS.register("resonating_linker_clear", () -> new SimpleCraftingRecipeSerializer<>(ResonatingLinkerClearRecipe::new));
+
+    public static final Supplier<RecipeSerializer<WirelessUniversalTerminalCombineRecipe>> WIRELESS_UNIVERSAL_TERMINAL_COMBINE = RECIPE_SERIALIZERS.register("wireless_universal_terminal_combine", () -> new SimpleCraftingRecipeSerializer<>(WirelessUniversalTerminalCombineRecipe::new));
 
     public static void register(IEventBus modEventBus) {
         RECIPE_SERIALIZERS.register(modEventBus);

--- a/src/main/java/io/github/lounode/ae2cs/common/menu/ResonantTemplateCodingTermMenu.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/menu/ResonantTemplateCodingTermMenu.java
@@ -1445,7 +1445,7 @@ public class ResonantTemplateCodingTermMenu extends PatternEncodingTermMenu impl
                 this.getSmithingTableTemplateSlot(),
                 this.getSmithingTableBaseSlot(),
                 this.getSmithingTableAdditionSlot()
-        }, recipe.value().getRemainingItems(input), player);
+        }, NonNullList.withSize(3, ItemStack.EMPTY), player);
         return result;
     }
 

--- a/src/main/java/io/github/lounode/ae2cs/common/recipe/WirelessUniversalTerminalCombineRecipe.java
+++ b/src/main/java/io/github/lounode/ae2cs/common/recipe/WirelessUniversalTerminalCombineRecipe.java
@@ -1,0 +1,121 @@
+package io.github.lounode.ae2cs.common.recipe;
+
+import io.github.lounode.ae2cs.common.init.AECSItems;
+import io.github.lounode.ae2cs.common.init.AECSRecipeSerializers;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingInput;
+import net.minecraft.world.item.crafting.CustomRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.Level;
+
+import de.mari_023.ae2wtlib.api.AE2wtlibAPI;
+import de.mari_023.ae2wtlib.api.registration.WTDefinition;
+import de.mari_023.ae2wtlib.wut.recipe.Common;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class WirelessUniversalTerminalCombineRecipe extends CustomRecipe {
+
+    public WirelessUniversalTerminalCombineRecipe(CraftingBookCategory category) {
+        super(category);
+    }
+
+    @Override
+    public boolean matches(CraftingInput input, @NotNull Level level) {
+        return findInputs(input) != null;
+    }
+
+    @Override
+    public @NotNull ItemStack assemble(CraftingInput input, HolderLookup.@NotNull Provider registries) {
+        Inputs inputs = findInputs(input);
+        if (inputs == null) {
+            return ItemStack.EMPTY;
+        }
+
+        ItemStack wut = new ItemStack(AE2wtlibAPI.getWUT());
+        wut = Common.mergeTerminal(wut, inputs.resonant(), inputs.resonantDefinition());
+        return Common.mergeTerminal(wut, inputs.other(), inputs.otherDefinition());
+    }
+
+    @Nullable
+    private static Inputs findInputs(CraftingInput input) {
+        if (input.ingredientCount() != 2) {
+            return null;
+        }
+
+        ItemStack resonant = ItemStack.EMPTY;
+        ItemStack other = ItemStack.EMPTY;
+        WTDefinition otherDefinition = null;
+
+        for (int i = 0; i < input.size(); i++) {
+            ItemStack stack = input.getItem(i);
+            if (stack.isEmpty()) {
+                continue;
+            }
+
+            if (stack.is(AECSItems.WIRELESS_RESONANT_TERMINAL.get())) {
+                if (!resonant.isEmpty()) {
+                    return null;
+                }
+                resonant = stack;
+                continue;
+            }
+
+            if (AE2wtlibAPI.isUniversalTerminal(stack)) {
+                return null;
+            }
+
+            WTDefinition definition = WTDefinition.ofOrNull(stack);
+            if (definition == null || definition.item() == AECSItems.WIRELESS_RESONANT_TERMINAL.get() || !other.isEmpty()) {
+                return null;
+            }
+            other = stack;
+            otherDefinition = definition;
+        }
+
+        if (resonant.isEmpty() || other.isEmpty() || otherDefinition == null) {
+            return null;
+        }
+
+        WTDefinition resonantDefinition = WTDefinition.ofOrNull(resonant);
+        if (resonantDefinition == null) {
+            return null;
+        }
+
+        return new Inputs(resonant, resonantDefinition, other, otherDefinition);
+    }
+
+    @Override
+    public boolean canCraftInDimensions(int width, int height) {
+        return width * height >= 2;
+    }
+
+    @Override
+    public @NotNull ItemStack getResultItem(HolderLookup.@NotNull Provider registries) {
+        return new ItemStack(AE2wtlibAPI.getWUT());
+    }
+
+    @Override
+    public @NotNull NonNullList<Ingredient> getIngredients() {
+        NonNullList<Ingredient> ingredients = NonNullList.create();
+        ingredients.add(Ingredient.of(AECSItems.WIRELESS_RESONANT_TERMINAL.get()));
+        ingredients.add(Ingredient.of(WTDefinition.wirelessTerminals().stream()
+                .filter(definition -> definition.item() != AECSItems.WIRELESS_RESONANT_TERMINAL.get())
+                .map(definition -> new ItemStack((ItemLike) definition.item()))
+                .toArray(ItemStack[]::new)));
+        return ingredients;
+    }
+
+    @Override
+    public @NotNull RecipeSerializer<?> getSerializer() {
+        return AECSRecipeSerializers.WIRELESS_UNIVERSAL_TERMINAL_COMBINE.get();
+    }
+
+    private record Inputs(ItemStack resonant, WTDefinition resonantDefinition, ItemStack other, WTDefinition otherDefinition) {}
+}

--- a/src/main/java/io/github/lounode/ae2cs/datagen/recipes/AECSMiscRecipeProvider.java
+++ b/src/main/java/io/github/lounode/ae2cs/datagen/recipes/AECSMiscRecipeProvider.java
@@ -5,6 +5,7 @@ import io.github.lounode.ae2cs.common.init.AECSBlocks;
 import io.github.lounode.ae2cs.common.init.AECSItems;
 import io.github.lounode.ae2cs.common.init.AECSTags;
 import io.github.lounode.ae2cs.common.recipe.ResonatingPatternUpgradeRecipe;
+import io.github.lounode.ae2cs.common.recipe.WirelessUniversalTerminalCombineRecipe;
 import io.github.lounode.ae2cs.datagen.AECSRecipeProvider;
 
 import appeng.core.definitions.AEBlocks;
@@ -62,6 +63,9 @@ public class AECSMiscRecipeProvider extends AECSRecipeProvider {
         // 添加谐振样板配方
         SpecialRecipeBuilder.special(ResonatingPatternUpgradeRecipe::new)
                 .save(recipeOutput, AE2CrystalScience.makeId("resonating_pattern_upgrade"));
+
+        SpecialRecipeBuilder.special(WirelessUniversalTerminalCombineRecipe::new)
+                .save(recipeOutput, AE2CrystalScience.makeId("wireless_universal_terminal_combine"));
 
         // 添加谐振样板拆解
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, AEItems.BLANK_PATTERN)

--- a/src/main/resources/assets/ae2cs/lang/en_us.json
+++ b/src/main/resources/assets/ae2cs/lang/en_us.json
@@ -514,5 +514,6 @@
   "ae2cs.menu.resonant_template_coding_terminal.hotkey_unbound": "Unbound",
   "ae2cs.tooltip.click_to_view_recipes": "Click to view recipes",
   "key.categories.ae2cs": "AE2 Crystal Science",
-  "key.ae2cs.toggle_resonant_template_coding_slot_mode": "Toggle Resonant Template Coding Terminal Slot Mode"
+  "key.ae2cs.toggle_resonant_template_coding_slot_mode": "Toggle Resonant Template Coding Terminal Slot Mode",
+  "key.ae2.wireless_ae2cs_resonant_pattern_encoding_terminal": "Open Wireless Resonant Crafting Encoding Terminal"
 }

--- a/src/main/resources/assets/ae2cs/lang/ja_jp.json
+++ b/src/main/resources/assets/ae2cs/lang/ja_jp.json
@@ -505,8 +505,8 @@
 "ae2cs.menu.resonant_template_coding_terminal.processing_ingredient_transfer_mode.full_split_desc": "JEI/EMI の表示順を保ち、重複する材料を統合しません",
 "ae2cs.menu.resonant_template_coding_terminal.hotkey_unbound": "未設定",
 "key.categories.ae2cs": "AE2 水晶科学",
-"key.ae2cs.toggle_resonant_template_coding_slot_mode": "共振パターンエンコード端末のスロットモード切替"
-,
+"key.ae2cs.toggle_resonant_template_coding_slot_mode": "共振パターンエンコード端末のスロットモード切替",
+  "key.ae2.wireless_ae2cs_resonant_pattern_encoding_terminal": "ワイヤレス共振クラフトエンコード端末を開く",
   "ae2cs.tooltip.click_to_view_recipes": "クリックしてレシピを表示",
   "ae2cs.item.resonating_linker.provider": "紐付け先サプライヤー: (%s, %s, %s)",
   "ae2cs.item.resonating_linker.provider.unbound": "紐付け先サプライヤー: なし",

--- a/src/main/resources/assets/ae2cs/lang/zh_cn.json
+++ b/src/main/resources/assets/ae2cs/lang/zh_cn.json
@@ -514,5 +514,6 @@
   "ae2cs.menu.resonant_template_coding_terminal.hotkey_unbound": "未设置",
   "ae2cs.tooltip.click_to_view_recipes": "点击查看配方",
   "key.categories.ae2cs": "AE2 水晶科技",
-  "key.ae2cs.toggle_resonant_template_coding_slot_mode": "切换谐振样板编码终端槽模式"
+  "key.ae2cs.toggle_resonant_template_coding_slot_mode": "切换谐振样板编码终端槽模式",
+  "key.ae2.wireless_ae2cs_resonant_pattern_encoding_terminal": "打开无线谐振合成编码终端"
 }

--- a/src/main/resources/assets/ae2cs/lang/zh_hk.json
+++ b/src/main/resources/assets/ae2cs/lang/zh_hk.json
@@ -514,5 +514,6 @@
   "ae2cs.menu.resonant_template_coding_terminal.hotkey_unbound": "未設置",
   "ae2cs.tooltip.click_to_view_recipes": "點擊查看配方",
   "key.categories.ae2cs": "AE2 水晶科技",
-  "key.ae2cs.toggle_resonant_template_coding_slot_mode": "切換諧振樣板編碼終端槽模式"
+  "key.ae2cs.toggle_resonant_template_coding_slot_mode": "切換諧振樣板編碼終端槽模式",
+  "key.ae2.wireless_ae2cs_resonant_pattern_encoding_terminal": "開啟無線諧振合成編碼終端"
 }

--- a/src/main/resources/data/ae2cs/recipe/wireless_universal_terminal/combine_resonant_with_ex_pattern_access.json
+++ b/src/main/resources/data/ae2cs/recipe/wireless_universal_terminal/combine_resonant_with_ex_pattern_access.json
@@ -1,0 +1,17 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "extendedae"
+    }
+  ],
+  "type": "ae2wtlib:combine",
+  "terminalA": {
+    "item": "ae2cs:wireless_resonant_terminal"
+  },
+  "terminalB": {
+    "item": "extendedae:wireless_ex_pat"
+  },
+  "terminalAName": "ae2cs_resonant_pattern_encoding",
+  "terminalBName": "ex_pattern_access"
+}


### PR DESCRIPTION
## 变更

- 谐振无线终端可通过运行时配方与任意已注册无线终端（含 ExtendedAE 无线扩展样板管理终端）合成无线通用终端
- 补全打开无线谐振合成编码终端快捷键的语言条目
- 锻造台拉取合成改为与原版锻造台一致的消耗逻辑，修复禁忌与奥秘永恒之石作用于转化之心时不消耗的问题
- 新增 `runClientJEI`（有 JEI、无 EMI），并补充若干运行时依赖

## 测试

- 谐振终端 + 无线扩展样板管理终端 → 无线通用终端
- 控制设置中快捷键显示为「打开无线谐振合成编码终端」
- 锻造台对永恒转化之心会消耗转化之心